### PR TITLE
Improve email marketing view

### DIFF
--- a/frontend/src/mock/emailCampaigns.json
+++ b/frontend/src/mock/emailCampaigns.json
@@ -1,4 +1,4 @@
 [
-  {"id":1,"title":"新品推广","group":"全部客户","status":"running"},
-  {"id":2,"title":"节日祝福","group":"潜在客户","status":"pending"}
+  {"id": 1, "name": "新品推广", "desc": "推广新品上市", "createdAt": "2023-10-01", "content": "<p>新品上线，快来购买！</p>"},
+  {"id": 2, "name": "节日祝福", "desc": "节日问候邮件", "createdAt": "2023-10-20", "content": "<p>节日快乐！</p>"}
 ]

--- a/frontend/src/mock/sendRecords.json
+++ b/frontend/src/mock/sendRecords.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "title": "新品推广", "status": "success", "time": "2023-11-01 10:00", "count": 1200},
+  {"id": 2, "title": "节日祝福", "status": "running", "time": "2023-11-05 09:00", "count": 850},
+  {"id": 3, "title": "促销活动", "status": "error", "time": "2023-11-08 14:30", "count": 600}
+]

--- a/frontend/src/mock/socialAccounts.json
+++ b/frontend/src/mock/socialAccounts.json
@@ -1,4 +1,5 @@
 [
-  {"platform": "Facebook", "account": "@fb_marketing", "status": "已绑定", "bindTime": "2024-01-01"},
-  {"platform": "Twitter", "account": "@twitter_acc", "status": "已绑定", "bindTime": "2024-02-10"}
+  {"id":1,"platform":"Facebook","name":"Brand Page","accessToken":"fb123","note":"主账号","status":"已绑定","bindTime":"2025-01-01"},
+  {"id":2,"platform":"LinkedIn","name":"Company Profile","accessToken":"ln456","note":"企业资料","status":"已绑定","bindTime":"2025-02-15"},
+  {"id":3,"platform":"Twitter","name":"MarketingBot","accessToken":"tw789","note":"","status":"已断开","bindTime":"2025-03-05"}
 ]

--- a/frontend/src/mock/socialPushLogs.json
+++ b/frontend/src/mock/socialPushLogs.json
@@ -1,0 +1,12 @@
+[
+  {"id":1,"accountId":1,"time":"2025-06-01 10:00","content":"发布新品信息","platform":"Facebook","status":"成功"},
+  {"id":2,"accountId":1,"time":"2025-06-02 10:00","content":"宣传活动","platform":"Facebook","status":"成功"},
+  {"id":3,"accountId":1,"time":"2025-06-03 10:00","content":"测试推送","platform":"Facebook","status":"失败"},
+  {"id":4,"accountId":2,"time":"2025-06-05 11:00","content":"更新招聘信息","platform":"LinkedIn","status":"成功"},
+  {"id":5,"accountId":2,"time":"2025-06-06 11:00","content":"分享行业新闻","platform":"LinkedIn","status":"成功"},
+  {"id":6,"accountId":2,"time":"2025-06-07 11:00","content":"发布职位空缺","platform":"LinkedIn","status":"失败"},
+  {"id":7,"accountId":3,"time":"2025-06-08 09:00","content":"每日问候","platform":"Twitter","status":"成功"},
+  {"id":8,"accountId":3,"time":"2025-06-09 09:00","content":"产品促销","platform":"Twitter","status":"失败"},
+  {"id":9,"accountId":3,"time":"2025-06-10 09:00","content":"转发用户评价","platform":"Twitter","status":"成功"},
+  {"id":10,"accountId":1,"time":"2025-06-11 10:00","content":"新品预告","platform":"Facebook","status":"成功"}
+]

--- a/frontend/src/mock/taskList.json
+++ b/frontend/src/mock/taskList.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": 1,
+    "name": "Daily Email Blast",
+    "desc": "Send promotional emails daily",
+    "cycle": "每天",
+    "startTime": "2024-01-01 08:00",
+    "enabled": true,
+    "tags": ["邮件", "推广"],
+    "lastRun": "2024-06-10 08:00",
+    "status": "success",
+    "actions": ["发送邮件"]
+  },
+  {
+    "id": 2,
+    "name": "Weekly Social Post",
+    "desc": "Post weekly updates",
+    "cycle": "每周",
+    "startTime": "2024-01-01 10:00",
+    "enabled": false,
+    "tags": ["社媒"],
+    "lastRun": "2024-06-07 10:00",
+    "status": "paused",
+    "actions": ["社媒发布"]
+  },
+  {
+    "id": 3,
+    "name": "Monthly Report",
+    "desc": "Generate monthly marketing report",
+    "cycle": "每月",
+    "startTime": "2024-01-01 09:00",
+    "enabled": true,
+    "tags": ["报告"],
+    "lastRun": "2024-06-01 09:00",
+    "status": "running",
+    "actions": ["生成报表"]
+  }
+]

--- a/frontend/src/views/EmailMarketingView.vue
+++ b/frontend/src/views/EmailMarketingView.vue
@@ -1,59 +1,196 @@
-<script setup>
-import { ref, onMounted } from 'vue'
-import RichTextEditor from '../components/RichTextEditor.vue'
-import campaignsJson from '../mock/emailCampaigns.json'
-
-const campaigns = ref([])
-const formVisible = ref(false)
-const form = ref({ title: '', group: '', content: '' })
-const groups = ['全部客户', '潜在客户', 'VIP']
-
-onMounted(() => {
-  campaigns.value = campaignsJson
-})
-
-function openCreate() {
-  form.value = { title: '', group: '', content: '' }
-  formVisible.value = true
-}
-</script>
-
 <template>
   <div class="page-wrapper">
-    <div class="action-buttons">
-      <el-button type="primary" @click="openCreate"><span class="icon">➕</span>新建邮件</el-button>
-    </div>
+    <el-tabs v-model="activeTab">
+      <el-tab-pane label="模板管理" name="templates">
+        <div class="action-buttons">
+          <el-button type="primary" @click="openTemplateDialog(false)"><span class="icon">➕</span>新建模板</el-button>
+        </div>
+        <el-card class="chart-container">
+          <el-table :data="templates" style="width:100%">
+            <el-table-column prop="name" label="名称" min-width="120" />
+            <el-table-column prop="desc" label="描述" />
+            <el-table-column prop="createdAt" label="创建时间" width="160" />
+            <el-table-column label="操作" width="180">
+              <template #default="{ row }">
+                <el-button type="text" @click="viewTemplate(row)">查看</el-button>
+                <el-button type="text" @click="openTemplateDialog(true, row)">编辑</el-button>
+                <el-button type="text" style="color:#f56c6c" @click="removeTemplate(row)">删除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-card>
+      </el-tab-pane>
 
-    <el-card class="chart-container">
-      <el-table :data="campaigns" style="width:100%">
-        <el-table-column prop="title" label="标题" />
-        <el-table-column prop="group" label="收件人组" />
-        <el-table-column prop="status" label="状态" width="120">
-          <template #default="scope">
-            <span :class="'status-badge status-' + scope.row.status">{{ scope.row.status }}</span>
-          </template>
-        </el-table-column>
-      </el-table>
-    </el-card>
+      <el-tab-pane label="群发配置" name="config">
+        <el-card class="chart-container">
+          <el-form :model="configForm" label-width="90px" style="max-width:600px;">
+            <el-form-item label="邮件标题">
+              <el-input v-model="configForm.title" />
+            </el-form-item>
+            <el-form-item label="选择模板">
+              <el-select v-model="configForm.templateId" placeholder="选择模板">
+                <el-option v-for="t in templates" :key="t.id" :label="t.name" :value="t.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="收件人分组">
+              <el-select v-model="configForm.groups" multiple placeholder="选择分组">
+                <el-option v-for="g in groups" :key="g" :label="g" :value="g" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="正文">
+              <RichTextEditor v-model="configForm.content" />
+            </el-form-item>
+            <el-form-item>
+              <div class="action-buttons">
+                <el-button type="primary" @click="saveConfig">保存配置</el-button>
+                <el-button @click="testDialogVisible = true">发送测试</el-button>
+                <el-button type="success" @click="sendNow">立即发送</el-button>
+              </div>
+            </el-form-item>
+          </el-form>
+        </el-card>
+      </el-tab-pane>
 
-    <el-dialog v-model="formVisible" title="邮件编辑" width="700px">
-      <el-form :model="form" label-width="80px">
-        <el-form-item label="邮件标题">
-          <el-input v-model="form.title" />
+      <el-tab-pane label="发送记录" name="records">
+        <el-card class="chart-container">
+          <el-table :data="sendRecords" style="width:100%">
+            <el-table-column prop="title" label="标题" />
+            <el-table-column prop="status" label="状态" width="120">
+              <template #default="{ row }">
+                <span :class="'status-badge status-' + row.status">{{ row.status }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column prop="time" label="时间" width="160" />
+            <el-table-column prop="count" label="发送人数" width="100" />
+          </el-table>
+        </el-card>
+      </el-tab-pane>
+    </el-tabs>
+
+    <!-- 模板编辑弹窗 -->
+    <el-dialog v-model="templateDialogVisible" :title="isEdit ? '编辑模板' : '新建模板'" width="600px">
+      <el-form :model="currentTemplate" label-width="80px">
+        <el-form-item label="名称">
+          <el-input v-model="currentTemplate.name" />
         </el-form-item>
-        <el-form-item label="收件人组">
-          <el-select v-model="form.group" placeholder="选择组">
-            <el-option v-for="g in groups" :key="g" :label="g" :value="g" />
-          </el-select>
+        <el-form-item label="描述">
+          <el-input v-model="currentTemplate.desc" />
         </el-form-item>
-        <el-form-item label="正文">
-          <RichTextEditor v-model="form.content" />
+        <el-form-item label="内容">
+          <RichTextEditor v-model="currentTemplate.content" />
         </el-form-item>
       </el-form>
       <template #footer>
-        <el-button @click="formVisible = false">取消</el-button>
-        <el-button type="primary" @click="formVisible = false">发送</el-button>
+        <el-button @click="templateDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="saveTemplate">保存</el-button>
+      </template>
+    </el-dialog>
+
+    <!-- 模板查看抽屉 -->
+    <el-drawer v-model="drawerVisible" title="模板详情" size="40%">
+      <h3>{{ currentTemplate.name }}</h3>
+      <p style="margin-bottom:10px;color:#666;">{{ currentTemplate.desc }}</p>
+      <div v-html="currentTemplate.content"></div>
+    </el-drawer>
+
+    <!-- 测试发送弹窗 -->
+    <el-dialog v-model="testDialogVisible" title="发送测试" width="400px">
+      <el-input v-model="testEmail" placeholder="输入测试邮箱" />
+      <template #footer>
+        <el-button @click="testDialogVisible = false">取消</el-button>
+        <el-button type="primary" @click="sendTest">发送</el-button>
       </template>
     </el-dialog>
   </div>
 </template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { ElMessageBox, ElMessage } from 'element-plus'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import templatesData from '../mock/emailCampaigns.json'
+import sendRecordsData from '../mock/sendRecords.json'
+
+const activeTab = ref('templates')
+const templates = ref([])
+const sendRecords = ref([])
+
+const templateDialogVisible = ref(false)
+const drawerVisible = ref(false)
+const isEdit = ref(false)
+const currentTemplate = ref({ id: null, name: '', desc: '', content: '', createdAt: '' })
+
+const configForm = ref({
+  title: '',
+  templateId: '',
+  groups: [],
+  content: ''
+})
+const groups = ['全部客户', '潜在客户', 'VIP']
+
+const testDialogVisible = ref(false)
+const testEmail = ref('')
+
+onMounted(() => {
+  templates.value = templatesData
+  sendRecords.value = sendRecordsData
+})
+
+function openTemplateDialog(edit, tpl) {
+  isEdit.value = edit
+  if (edit && tpl) {
+    currentTemplate.value = { ...tpl }
+  } else {
+    currentTemplate.value = { id: null, name: '', desc: '', content: '', createdAt: '' }
+  }
+  templateDialogVisible.value = true
+}
+
+function saveTemplate() {
+  if (isEdit.value && currentTemplate.value.id) {
+    const idx = templates.value.findIndex(t => t.id === currentTemplate.value.id)
+    templates.value.splice(idx, 1, { ...currentTemplate.value })
+    ElMessage.success('模板已更新')
+  } else {
+    currentTemplate.value.id = templates.value.length ? Math.max(...templates.value.map(t => t.id)) + 1 : 1
+    currentTemplate.value.createdAt = new Date().toISOString().split('T')[0]
+    templates.value.push({ ...currentTemplate.value })
+    ElMessage.success('模板已创建')
+  }
+  templateDialogVisible.value = false
+}
+
+function viewTemplate(row) {
+  currentTemplate.value = { ...row }
+  drawerVisible.value = true
+}
+
+function removeTemplate(row) {
+  ElMessageBox.confirm('确定删除该模板吗?', '提示', { type: 'warning' })
+    .then(() => {
+      templates.value = templates.value.filter(t => t.id !== row.id)
+      ElMessage.success('已删除')
+    })
+    .catch(() => {})
+}
+
+function saveConfig() {
+  ElMessage.success('配置已保存')
+}
+
+function sendTest() {
+  testDialogVisible.value = false
+  ElMessage.success('测试邮件已发送到 ' + testEmail.value)
+}
+
+function sendNow() {
+  sendRecords.value.push({
+    id: sendRecords.value.length ? Math.max(...sendRecords.value.map(r => r.id)) + 1 : 1,
+    title: configForm.value.title,
+    status: 'running',
+    time: new Date().toLocaleString(),
+    count: 0
+  })
+  ElMessage.success('发送任务已创建')
+}
+</script>

--- a/frontend/src/views/SocialMediaView.vue
+++ b/frontend/src/views/SocialMediaView.vue
@@ -1,79 +1,183 @@
-<script setup>
-import { ref, onMounted } from 'vue'
-import accountsJson from '../mock/socialAccounts.json'
-import postsJson from '../mock/socialPosts.json'
-
-const accounts = ref([])
-const posts = ref([])
-const dialogVisible = ref(false)
-const newAccount = ref({ platform: '', account: '' })
-
-onMounted(() => {
-  accounts.value = accountsJson
-  posts.value = postsJson
-})
-
-function addAccount() {
-  accounts.value.push({ ...newAccount.value, status: '已绑定', bindTime: new Date().toISOString().slice(0,10) })
-  newAccount.value = { platform: '', account: '' }
-  dialogVisible.value = false
-}
-
-function removeAccount(row) {
-  accounts.value = accounts.value.filter(a => a !== row)
-}
-</script>
-
 <template>
   <div class="page-wrapper">
     <div class="action-buttons">
-      <el-button type="primary" @click="dialogVisible = true"><span class="icon">➕</span>添加账号</el-button>
+      <el-select v-model="filterPlatform" placeholder="平台" style="width:120px">
+        <el-option label="全部" value="" />
+        <el-option v-for="p in platforms" :key="p" :label="p" :value="p" />
+      </el-select>
+      <el-input v-model="keyword" placeholder="搜索账号" clearable style="width:200px" />
+      <el-button type="primary" @click="toggleAdd"><span class="icon">➕</span>添加账号</el-button>
     </div>
 
-    <el-card class="chart-container">
-      <h3>已绑定账号</h3>
-      <el-table :data="accounts" style="width:100%">
-        <el-table-column prop="platform" label="平台" width="120" />
-        <el-table-column prop="account" label="账号" width="180" />
-        <el-table-column prop="status" label="状态" width="100" />
-        <el-table-column prop="bindTime" label="绑定时间" width="180" />
-        <el-table-column label="操作" width="100">
-          <template #default="{ row }">
-            <el-button type="text" @click="removeAccount(row)">解绑</el-button>
-          </template>
-        </el-table-column>
-      </el-table>
-    </el-card>
+    <el-collapse v-model="addSection" style="margin-bottom:20px;">
+      <el-collapse-item name="add">
+        <template #title>新增账号</template>
+        <el-form :model="addForm" label-width="90px" class="form-section" style="max-width:600px;margin-top:10px;">
+          <el-form-item label="平台类型">
+            <el-select v-model="addForm.platform" placeholder="选择平台">
+              <el-option label="Facebook" value="Facebook" />
+              <el-option label="LinkedIn" value="LinkedIn" />
+              <el-option label="Twitter" value="Twitter" />
+            </el-select>
+          </el-form-item>
+          <el-form-item label="账号名">
+            <el-input v-model="addForm.name" />
+          </el-form-item>
+          <el-form-item label="AccessToken">
+            <el-input v-model="addForm.token" />
+          </el-form-item>
+          <el-form-item label="备注">
+            <el-input v-model="addForm.note" />
+          </el-form-item>
+          <el-form-item>
+            <el-button type="primary" @click="addAccount">添加</el-button>
+          </el-form-item>
+        </el-form>
+      </el-collapse-item>
+    </el-collapse>
 
-    <el-card class="chart-container">
-      <h3>推文计划</h3>
-      <el-table :data="posts" style="width:100%">
-        <el-table-column prop="platform" label="平台" width="120" />
-        <el-table-column prop="content" label="内容" />
-        <el-table-column prop="status" label="状态" width="120">
-          <template #default="scope">
-            <span :class="'status-badge status-' + scope.row.status">{{ scope.row.status }}</span>
+    <el-row :gutter="20">
+      <el-col v-for="acc in filteredAccounts" :key="acc.id" :xs="24" :sm="12" :md="8" style="margin-bottom:20px;">
+        <el-card>
+          <template #header>
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+              <span>{{ acc.platform }}</span>
+              <div>
+                <el-tooltip content="编辑">
+                  <el-button text size="small" @click="openDrawer(acc)"><el-icon><Edit /></el-icon></el-button>
+                </el-tooltip>
+                <el-tooltip content="解绑">
+                  <el-button text size="small" style="color:#f56c6c" @click="unbind(acc)"><el-icon><Delete /></el-icon></el-button>
+                </el-tooltip>
+                <el-tooltip content="推送日志">
+                  <el-button text size="small" @click="openLogs(acc)"><el-icon><Document /></el-icon></el-button>
+                </el-tooltip>
+              </div>
+            </div>
           </template>
-        </el-table-column>
-      </el-table>
-    </el-card>
+          <div style="margin-bottom:10px;">
+            <span :class="['status-badge', acc.status === '已绑定' ? 'status-success' : 'status-error']">{{ acc.status }}</span>
+          </div>
+          <p>{{ acc.name }}</p>
+          <p style="color:#999;font-size:12px;">绑定于 {{ acc.bindTime }}</p>
+        </el-card>
+      </el-col>
+    </el-row>
 
-    <el-dialog v-model="dialogVisible" title="添加账号" width="400px">
-      <el-form :model="newAccount" label-width="80px">
-        <el-form-item label="平台">
-          <el-select v-model="newAccount.platform" placeholder="选择平台">
+    <el-drawer v-model="drawerVisible" title="编辑账号" size="30%">
+      <el-form :model="editForm" label-width="90px" class="form-section">
+        <el-form-item label="平台类型">
+          <el-select v-model="editForm.platform">
             <el-option label="Facebook" value="Facebook" />
+            <el-option label="LinkedIn" value="LinkedIn" />
             <el-option label="Twitter" value="Twitter" />
           </el-select>
         </el-form-item>
-        <el-form-item label="账号">
-          <el-input v-model="newAccount.account" />
+        <el-form-item label="账号名">
+          <el-input v-model="editForm.name" />
+        </el-form-item>
+        <el-form-item label="AccessToken">
+          <el-input v-model="editForm.token" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="editForm.note" />
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-switch v-model="editForm.statusSwitch" active-text="已绑定" inactive-text="已断开" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="saveEdit">保存</el-button>
         </el-form-item>
       </el-form>
-      <template #footer>
-        <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="addAccount">确认</el-button>
-      </template>
+    </el-drawer>
+
+    <el-dialog v-model="logDialogVisible" title="推送日志" width="600px">
+      <el-table :data="logsForAccount" style="width:100%">
+        <el-table-column prop="time" label="时间" width="160" />
+        <el-table-column prop="content" label="内容" />
+        <el-table-column prop="status" label="状态" width="120">
+          <template #default="{ row }">
+            <span :class="['status-badge', row.status === '成功' ? 'status-success' : 'status-error']">{{ row.status }}</span>
+          </template>
+        </el-table-column>
+      </el-table>
     </el-dialog>
   </div>
 </template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Edit, Delete, Document } from '@element-plus/icons-vue'
+import accountsData from '../mock/socialAccounts.json'
+import logsData from '../mock/socialPushLogs.json'
+
+const accounts = ref([])
+const logs = ref([])
+const filterPlatform = ref('')
+const keyword = ref('')
+const addSection = ref([])
+const addForm = ref({ platform: '', name: '', token: '', note: '' })
+const drawerVisible = ref(false)
+const editForm = ref({ id: null, platform: '', name: '', token: '', note: '', status: '已绑定', bindTime: '', statusSwitch: true })
+const logDialogVisible = ref(false)
+const currentAccountId = ref(null)
+
+onMounted(() => {
+  accounts.value = accountsData.map(a => ({ ...a, statusSwitch: a.status === '已绑定' }))
+  logs.value = logsData
+})
+
+const platforms = computed(() => {
+  const set = new Set(accounts.value.map(a => a.platform))
+  return Array.from(set)
+})
+
+const filteredAccounts = computed(() => {
+  let list = accounts.value
+  if (filterPlatform.value) list = list.filter(a => a.platform === filterPlatform.value)
+  if (keyword.value) list = list.filter(a => a.name.includes(keyword.value))
+  return list
+})
+
+function toggleAdd() {
+  addSection.value = addSection.value.length ? [] : ['add']
+}
+
+function addAccount() {
+  const id = accounts.value.length ? Math.max(...accounts.value.map(a => a.id)) + 1 : 1
+  accounts.value.push({ ...addForm.value, id, status: '已绑定', bindTime: new Date().toISOString().split('T')[0], statusSwitch: true })
+  addForm.value = { platform: '', name: '', token: '', note: '' }
+  addSection.value = []
+  ElMessage.success('账号已添加')
+}
+
+function openDrawer(acc) {
+  editForm.value = { ...acc, statusSwitch: acc.status === '已绑定' }
+  drawerVisible.value = true
+}
+
+function saveEdit() {
+  const idx = accounts.value.findIndex(a => a.id === editForm.value.id)
+  editForm.value.status = editForm.value.statusSwitch ? '已绑定' : '已断开'
+  accounts.value.splice(idx, 1, { ...editForm.value })
+  drawerVisible.value = false
+  ElMessage.success('账号信息已更新')
+}
+
+function unbind(acc) {
+  ElMessageBox.confirm('确定解绑该账号吗?', '提示', { type: 'warning' })
+    .then(() => {
+      accounts.value = accounts.value.filter(a => a.id !== acc.id)
+      ElMessage.success('已解绑')
+    })
+    .catch(() => {})
+}
+
+function openLogs(acc) {
+  currentAccountId.value = acc.id
+  logDialogVisible.value = true
+}
+
+const logsForAccount = computed(() => logs.value.filter(l => l.accountId === currentAccountId.value))
+</script>

--- a/frontend/src/views/TaskScheduleView.vue
+++ b/frontend/src/views/TaskScheduleView.vue
@@ -1,62 +1,202 @@
-<script setup>
-import { ref, onMounted } from 'vue'
-import scheduleJson from '../mock/schedules.json'
-
-const schedules = ref([])
-const dialogVisible = ref(false)
-const form = ref({ name: '', frequency: '每天', startTime: '' })
-
-onMounted(() => { schedules.value = scheduleJson })
-
-function openDialog() {
-  form.value = { name: '', frequency: '每天', startTime: '' }
-  dialogVisible.value = true
-}
-function addTask() {
-  schedules.value.push({ ...form.value, status: 'pending' })
-  dialogVisible.value = false
-}
-</script>
-
 <template>
   <div class="page-wrapper">
     <div class="action-buttons">
-      <el-button type="primary" @click="openDialog"><span class="icon">➕</span>新建任务</el-button>
+      <el-button type="primary" @click="openDialog(false)"><span class="icon">➕</span>新建任务</el-button>
+      <el-select v-model="filterStatus" placeholder="状态" style="width:120px">
+        <el-option label="全部" value="" />
+        <el-option label="进行中" value="running" />
+        <el-option label="成功" value="success" />
+        <el-option label="失败" value="error" />
+        <el-option label="已暂停" value="paused" />
+      </el-select>
+      <el-select v-model="filterTags" multiple placeholder="标签" style="min-width:180px">
+        <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
+      </el-select>
+      <el-input v-model="searchKey" placeholder="关键词搜索" clearable style="width:200px" />
     </div>
 
-    <el-card class="chart-container">
-      <el-table :data="schedules" style="width:100%">
-        <el-table-column prop="name" label="任务名称" />
-        <el-table-column prop="frequency" label="频率" width="120" />
-        <el-table-column prop="startTime" label="开始时间" width="160" />
-        <el-table-column prop="status" label="状态" width="120">
-          <template #default="scope">
-            <span :class="'status-badge status-' + (scope.row.status || 'pending')">{{ scope.row.status || 'pending' }}</span>
+    <el-card class="task-list">
+      <el-table :data="filtered" style="width:100%">
+        <el-table-column prop="name" label="任务名称" min-width="160" />
+        <el-table-column prop="cycle" label="周期" width="80" />
+        <el-table-column label="状态" width="120">
+          <template #default="{ row }">
+            <span :class="'status-badge status-' + row.status">{{ row.status }}</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="lastRun" label="上次执行时间" width="160" />
+        <el-table-column label="操作" width="220">
+          <template #default="{ row }">
+            <el-button type="text" @click="viewDetail(row)">查看</el-button>
+            <el-button type="text" @click="openDialog(true, row)">编辑</el-button>
+            <el-switch v-model="row.enabled" @change="toggleEnabled(row)" size="small" style="margin:0 5px" />
+            <el-button type="text" style="color:#f56c6c" @click="removeTask(row)">删除</el-button>
           </template>
         </el-table-column>
       </el-table>
     </el-card>
 
-    <el-dialog v-model="dialogVisible" title="创建任务" width="500px">
-      <el-form :model="form" label-width="80px">
+    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑任务' : '新建任务'" width="600px">
+      <el-form :model="form" label-width="90px" class="form-section">
         <el-form-item label="任务名称">
           <el-input v-model="form.name" />
         </el-form-item>
-        <el-form-item label="频率">
-          <el-select v-model="form.frequency">
+        <el-form-item label="描述">
+          <el-input v-model="form.desc" />
+        </el-form-item>
+        <el-form-item label="执行周期">
+          <el-select v-model="form.cycle">
             <el-option label="每天" value="每天" />
             <el-option label="每周" value="每周" />
             <el-option label="每月" value="每月" />
           </el-select>
         </el-form-item>
-        <el-form-item label="开始时间">
-          <el-input v-model="form.startTime" placeholder="08:00" />
+        <el-form-item label="起始时间">
+          <el-date-picker v-model="form.startTime" type="datetime" placeholder="选择日期时间" style="width:100%" />
+        </el-form-item>
+        <el-form-item label="是否启用">
+          <el-switch v-model="form.enabled" />
+        </el-form-item>
+        <el-form-item label="营销动作">
+          <el-select v-model="form.actions" multiple placeholder="选择动作">
+            <el-option label="发送邮件" value="发送邮件" />
+            <el-option label="社媒发布" value="社媒发布" />
+            <el-option label="生成报表" value="生成报表" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="标签">
+          <el-select v-model="form.tags" multiple placeholder="请选择标签">
+            <el-option v-for="t in allTags" :key="t" :label="t" :value="t" />
+          </el-select>
         </el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="addTask">确定</el-button>
+        <el-button type="primary" @click="saveForm">保存</el-button>
       </template>
     </el-dialog>
+
+    <el-drawer v-model="drawerVisible" title="任务详情" size="40%">
+      <h3>{{ currentDetail.name }}</h3>
+      <p>{{ currentDetail.desc }}</p>
+      <el-descriptions :column="1" style="margin-top:10px">
+        <el-descriptions-item label="周期">{{ currentDetail.cycle }}</el-descriptions-item>
+        <el-descriptions-item label="启用">{{ currentDetail.enabled ? '是' : '否' }}</el-descriptions-item>
+        <el-descriptions-item label="上次执行">{{ currentDetail.lastRun }}</el-descriptions-item>
+        <el-descriptions-item label="营销动作">
+          <el-tag v-for="a in currentDetail.actions" :key="a" size="small" style="margin-right:4px">{{ a }}</el-tag>
+        </el-descriptions-item>
+        <el-descriptions-item label="标签">
+          <el-tag v-for="t in currentDetail.tags" :key="t" size="small" style="margin-right:4px">{{ t }}</el-tag>
+        </el-descriptions-item>
+      </el-descriptions>
+      <h4 style="margin:20px 0 10px;">运行日志</h4>
+      <el-timeline>
+        <el-timeline-item v-for="n in 3" :key="n" timestamp="2024-06-10 08:00">执行日志 {{ n }}</el-timeline-item>
+      </el-timeline>
+    </el-drawer>
   </div>
 </template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import data from '../mock/taskList.json'
+
+const tasks = ref([])
+const allTags = ref([])
+const filterStatus = ref('')
+const filterTags = ref([])
+const searchKey = ref('')
+
+const dialogVisible = ref(false)
+const drawerVisible = ref(false)
+const isEdit = ref(false)
+
+const form = ref({
+  id: null,
+  name: '',
+  desc: '',
+  cycle: '每天',
+  startTime: '',
+  enabled: true,
+  actions: [],
+  tags: []
+})
+
+const currentDetail = ref({})
+
+onMounted(() => {
+  tasks.value = data
+  const tagSet = new Set()
+  data.forEach(t => t.tags.forEach(tag => tagSet.add(tag)))
+  allTags.value = Array.from(tagSet)
+})
+
+const filtered = computed(() => {
+  let result = tasks.value
+  if (filterStatus.value) {
+    result = result.filter(t => t.status === filterStatus.value)
+  }
+  if (filterTags.value.length) {
+    result = result.filter(t => filterTags.value.every(f => t.tags.includes(f)))
+  }
+  if (searchKey.value) {
+    result = result.filter(t => t.name.includes(searchKey.value) || t.desc.includes(searchKey.value))
+  }
+  return result
+})
+
+function openDialog(edit, row) {
+  isEdit.value = edit
+  if (edit && row) {
+    form.value = { ...row }
+  } else {
+    form.value = {
+      id: null,
+      name: '',
+      desc: '',
+      cycle: '每天',
+      startTime: '',
+      enabled: true,
+      actions: [],
+      tags: []
+    }
+  }
+  dialogVisible.value = true
+}
+
+function saveForm() {
+  if (isEdit.value) {
+    const idx = tasks.value.findIndex(t => t.id === form.value.id)
+    tasks.value.splice(idx, 1, { ...form.value })
+    ElMessage.success('更新成功')
+  } else {
+    form.value.id = tasks.value.length ? Math.max(...tasks.value.map(t => t.id)) + 1 : 1
+    form.value.status = 'pending'
+    form.value.lastRun = ''
+    tasks.value.push({ ...form.value })
+    ElMessage.success('创建成功')
+  }
+  dialogVisible.value = false
+}
+
+function removeTask(row) {
+  ElMessageBox.confirm('确定删除该任务吗?', '提示', { type: 'warning' })
+    .then(() => {
+      tasks.value = tasks.value.filter(t => t.id !== row.id)
+      ElMessage.success('已删除')
+    })
+    .catch(() => {})
+}
+
+function toggleEnabled(row) {
+  row.enabled = !row.enabled
+  row.status = row.enabled ? 'running' : 'paused'
+}
+
+function viewDetail(row) {
+  currentDetail.value = row
+  drawerVisible.value = true
+}
+</script>


### PR DESCRIPTION
## Summary
- redesign SocialMediaView with filterable account cards, collapsible add form, edit drawer and log dialog
- extend mock socialAccounts dataset and add socialPushLogs for log dialog

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden due to missing internet)*

------
https://chatgpt.com/codex/tasks/task_e_68772b97e06c8326a215216ce9429e9d