### PR TITLE
Integrate permission API

### DIFF
--- a/frontend/src/api/permission.ts
+++ b/frontend/src/api/permission.ts
@@ -1,0 +1,13 @@
+import request from '../utils/request'
+
+export function getRoleList() {
+  return request.get('/api/v1/roles')
+}
+
+export function getPermissionTree(roleId: number | string) {
+  return request.get(`/api/v1/roles/${roleId}/permissions`)
+}
+
+export function savePermissions(roleId: number | string, permissions: string[]) {
+  return request.post(`/api/v1/roles/${roleId}/permissions`, { permissions })
+}

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+const request = axios.create({
+  timeout: 10000,
+})
+
+request.interceptors.response.use(
+  response => response.data,
+  error => Promise.reject(error)
+)
+
+export default request


### PR DESCRIPTION
## Summary
- add simple axios request wrapper
- create permission API module
- connect PermissionView with backend APIs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687763c21fb88326ab2afd53a7fe6ca9