### PR TITLE
Refactor role management tab

### DIFF
--- a/frontend/src/components/RoleCard.vue
+++ b/frontend/src/components/RoleCard.vue
@@ -1,20 +1,77 @@
 <script setup>
-const props = defineProps(['role'])
+import { More, Edit, Delete } from '@element-plus/icons-vue'
+
+const props = defineProps({
+  role: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['edit', 'delete'])
+
+function handleCommand(cmd) {
+  if (cmd === 'edit') emit('edit', props.role)
+  if (cmd === 'delete') emit('delete', props.role)
+}
 </script>
 
 <template>
   <el-card class="role-card">
     <div class="role-header">
-      <div>
+      <div class="info">
         <div class="role-name">{{ props.role.name }}</div>
         <div class="role-description">{{ props.role.description }}</div>
       </div>
+      <el-dropdown trigger="click" @command="handleCommand">
+        <el-button text class="more-btn">
+          <el-icon><More /></el-icon>
+        </el-button>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item command="edit"><el-icon><Edit /></el-icon> 编辑</el-dropdown-item>
+            <el-dropdown-item command="delete"><el-icon><Delete /></el-icon> 删除</el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
     </div>
     <div class="permission-tags">
       <el-tag v-for="p in props.role.permissions" :key="p" size="small" type="info">{{ p }}</el-tag>
     </div>
     <div class="user-avatar-list">
-      <el-avatar v-for="u in props.role.users" :key="u.id" :src="u.avatar" :size="30" />
+      <el-tooltip v-for="u in props.role.users" :key="u.id" :content="u.name" placement="top">
+        <el-avatar :src="u.avatar" :size="30">{{ u.name?.charAt(0) }}</el-avatar>
+      </el-tooltip>
     </div>
   </el-card>
 </template>
+
+<style scoped>
+.role-card {
+  margin-bottom: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+.role-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.role-name {
+  font-weight: 500;
+  font-size: 16px;
+}
+.role-description {
+  font-size: 13px;
+  color: #666;
+}
+.permission-tags {
+  margin-bottom: 8px;
+}
+.user-avatar-list :deep(.el-avatar) {
+  margin-right: 4px;
+}
+.more-btn {
+  padding: 0;
+}
+</style>

--- a/frontend/src/views/permission/RoleManagementTab.vue
+++ b/frontend/src/views/permission/RoleManagementTab.vue
@@ -3,13 +3,9 @@
     <div class="toolbar mb-3">
       <el-button type="primary" icon="Plus" @click="openDialog">新建角色</el-button>
     </div>
-    <el-row :gutter="20">
+    <el-row :gutter="20" v-loading="loading">
       <el-col :span="8" v-for="role in roles" :key="role.id">
-        <RoleCard :role="role" />
-        <div style="text-align:right; margin-top:6px;">
-          <el-button type="primary" size="small" icon="Edit" @click="openDialog(role)">编辑</el-button>
-          <el-button type="danger" size="small" icon="Delete" @click="remove(role)">删除</el-button>
-        </div>
+        <RoleCard :role="role" @edit="openDialog" @delete="remove" />
       </el-col>
     </el-row>
 
@@ -39,29 +35,13 @@
 </template>
 
 <script setup>
-import { ref, reactive } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import RoleCard from '../../components/RoleCard.vue'
+import { getRoleList, createRole, updateRole, deleteRole } from '../../api/roleApi'
 
-const roles = ref([
-  {
-    id: 1,
-    name: '管理员',
-    description: '拥有全部权限',
-    permissions: ['add_user', 'delete_user', 'view_reports'],
-    users: [
-      { id: 1, name: '张三', avatar: '' },
-      { id: 2, name: '李四', avatar: '' }
-    ]
-  },
-  {
-    id: 2,
-    name: '编辑',
-    description: '内容管理',
-    permissions: ['edit_content', 'publish_content'],
-    users: [{ id: 3, name: '王五', avatar: '' }]
-  }
-])
+const roles = ref([])
+const loading = ref(false)
 const treeData = ref([
   {
     id: 1,
@@ -91,6 +71,22 @@ const isEdit = ref(false)
 const form = reactive({ id: '', name: '', description: '' })
 const treeRef = ref()
 
+onMounted(fetchRoles)
+
+function fetchRoles() {
+  loading.value = true
+  getRoleList()
+    .then(res => {
+      roles.value = res.data || []
+    })
+    .catch(() => {
+      ElMessage.error('加载失败')
+    })
+    .finally(() => {
+      loading.value = false
+    })
+}
+
 function openDialog(role) {
   if (role) {
     isEdit.value = true
@@ -105,28 +101,26 @@ function openDialog(role) {
 
 function save() {
   const permissions = treeRef.value?.getCheckedKeys() || []
-  if (isEdit.value) {
-    const index = roles.value.findIndex(r => r.id === form.id)
-    if (index !== -1) {
-      roles.value[index] = { ...roles.value[index], ...form, permissions }
-    }
-    ElMessage.success('更新成功')
-  } else {
-    roles.value.push({
-      id: Date.now(),
-      name: form.name,
-      description: form.description,
-      permissions,
-      users: []
+  const data = { name: form.name, description: form.description, permissions }
+  const req = isEdit.value ? updateRole(form.id, data) : createRole(data)
+  req
+    .then(() => {
+      ElMessage.success(isEdit.value ? '更新成功' : '创建成功')
+      dialogVisible.value = false
+      fetchRoles()
     })
-    ElMessage.success('创建成功')
-  }
-  dialogVisible.value = false
+    .catch(() => {
+      ElMessage.error('保存失败')
+    })
 }
 
 function remove(role) {
-  roles.value = roles.value.filter(r => r.id !== role.id)
-  ElMessage.success('已删除')
+  deleteRole(role.id)
+    .then(() => {
+      ElMessage.success('已删除')
+      fetchRoles()
+    })
+    .catch(() => ElMessage.error('删除失败'))
 
 }
 </script>


### PR DESCRIPTION
## Summary
- modernize RoleCard UI and add action dropdown
- connect `RoleManagementTab` with backend APIs
- add loading state and card-style layout

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878637efa9c83268e2a8b3172e59026