### PR TITLE
Enhance permission API

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
@@ -40,7 +40,7 @@ public class PermissionController {
                 .orElse(ResponseEntity.fail(404, "Not Found"));
     }
 
-    @PostMapping
+    @PostMapping(consumes = "application/json")
     @PreAuthorize("hasPermission('permission:create')")
     public ResponseEntity<Permission> create(@RequestBody Permission permission) {
         return ResponseEntity.success(permissionService.create(permission));
@@ -65,10 +65,21 @@ public class PermissionController {
         return ResponseEntity.success(null);
     }
 
-    @DeleteMapping
+    @PostMapping("/delete-batch")
     @PreAuthorize("hasPermission('permission:delete')")
     public ResponseEntity<Void> deleteBatch(@RequestBody List<String> ids) {
         permissionService.deleteBatch(ids);
+        return ResponseEntity.success(null);
+    }
+
+    @PutMapping("/{id}/status")
+    @PreAuthorize("hasPermission('permission:update')")
+    public ResponseEntity<Void> updateStatus(@PathVariable String id, @RequestBody java.util.Map<String, Boolean> body) {
+        Boolean status = body.get("status");
+        if (status == null) {
+            return ResponseEntity.fail(400, "status required");
+        }
+        permissionService.updateStatus(id, status);
         return ResponseEntity.success(null);
     }
 }

--- a/backend/src/main/java/com/platform/marketing/controller/RoleController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/RoleController.java
@@ -23,6 +23,16 @@ public class RoleController {
         return ResponseEntity.success(roleService.findAllRoles());
     }
 
+    @PostMapping
+    public ResponseEntity<Role> createRole(@RequestBody Role role) {
+        return ResponseEntity.success(roleService.create(role));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Role> updateRole(@PathVariable String id, @RequestBody Role role) {
+        return ResponseEntity.success(roleService.update(id, role));
+    }
+
     @GetMapping("/{id}/permissions")
     public ResponseEntity<List<String>> getRolePermissions(@PathVariable String id) {
         List<String> list = roleService.getPermissions(id);
@@ -35,3 +45,5 @@ public class RoleController {
         return ResponseEntity.success(null);
     }
 }
+
+

--- a/backend/src/main/java/com/platform/marketing/controller/UserController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/UserController.java
@@ -1,0 +1,44 @@
+package com.platform.marketing.controller;
+
+import com.platform.marketing.entity.User;
+import com.platform.marketing.service.UserService;
+import com.platform.marketing.util.ResponseEntity;
+import com.platform.marketing.util.ResponsePageDataEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponsePageDataEntity<User>> list(@RequestParam(defaultValue = "") String keyword,
+                                                             @RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "10") int size) {
+        Page<User> p = userService.search(keyword, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody User user) {
+        return ResponseEntity.success(userService.create(user));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> update(@PathVariable String id, @RequestBody User user) {
+        return ResponseEntity.success(userService.update(id, user));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        userService.delete(id);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/entity/User.java
+++ b/backend/src/main/java/com/platform/marketing/entity/User.java
@@ -1,0 +1,61 @@
+package com.platform.marketing.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    private String email;
+
+    @Column(name = "role_id")
+    private String roleId;
+
+    private boolean status = true;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getRoleId() { return roleId; }
+    public void setRoleId(String roleId) { this.roleId = roleId; }
+
+    public boolean isStatus() { return status; }
+    public void setStatus(boolean status) { this.status = status; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/platform/marketing/repository/UserRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.repository;
+
+import com.platform.marketing.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+    @Query("SELECT u FROM User u WHERE (:kw = '' OR lower(u.username) LIKE lower(concat('%', :kw, '%')) " +
+           "OR lower(u.email) LIKE lower(concat('%', :kw, '%')))")
+    Page<User> search(@Param("kw") String keyword, Pageable pageable);
+}

--- a/backend/src/main/java/com/platform/marketing/service/PermissionService.java
+++ b/backend/src/main/java/com/platform/marketing/service/PermissionService.java
@@ -16,6 +16,8 @@ public interface PermissionService {
     void delete(String id);
     void deleteBatch(List<String> ids);
 
+    void updateStatus(String id, boolean status);
+
     Page<Permission> search(String keyword, String type, Boolean status, Pageable pageable);
 
     List<com.platform.marketing.dto.PermissionTreeNode> getTree();

--- a/backend/src/main/java/com/platform/marketing/service/RoleService.java
+++ b/backend/src/main/java/com/platform/marketing/service/RoleService.java
@@ -33,6 +33,18 @@ public class RoleService {
         return roleRepository.findAll();
     }
 
+    public Role create(Role role) {
+        return roleRepository.save(role);
+    }
+
+    public Role update(String id, Role role) {
+        Role existing = roleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Role not found"));
+        existing.setName(role.getName());
+        existing.setDescription(role.getDescription());
+        return roleRepository.save(existing);
+    }
+
     public List<String> getPermissions(String roleId) {
         List<RolePermission> list = rolePermissionRepository.findByIdRoleId(roleId);
         return list.stream()
@@ -54,3 +66,4 @@ public class RoleService {
         }
     }
 }
+

--- a/backend/src/main/java/com/platform/marketing/service/UserService.java
+++ b/backend/src/main/java/com/platform/marketing/service/UserService.java
@@ -1,0 +1,12 @@
+package com.platform.marketing.service;
+
+import com.platform.marketing.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserService {
+    Page<User> search(String keyword, Pageable pageable);
+    User create(User user);
+    User update(String id, User user);
+    void delete(String id);
+}

--- a/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
@@ -85,6 +85,16 @@ public class PermissionServiceImpl implements PermissionService {
     }
 
     @Override
+    @Transactional
+    public void updateStatus(String id, boolean status) {
+        Permission p = permissionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Permission not found"));
+        p.setStatus(status);
+        p.setUpdatedBy(currentUser());
+        permissionRepository.save(p);
+    }
+
+    @Override
     public List<com.platform.marketing.dto.PermissionTreeNode> getTree() {
         List<Permission> all = permissionRepository.findAll();
         java.util.Map<String, com.platform.marketing.dto.PermissionTreeNode> map = new java.util.HashMap<>();

--- a/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
@@ -1,0 +1,48 @@
+package com.platform.marketing.service.impl;
+
+import com.platform.marketing.entity.User;
+import com.platform.marketing.repository.UserRepository;
+import com.platform.marketing.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+
+    public UserServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Page<User> search(String keyword, Pageable pageable) {
+        if (keyword == null) keyword = "";
+        return userRepository.search(keyword, pageable);
+    }
+
+    @Override
+    @Transactional
+    public User create(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public User update(String id, User user) {
+        User existing = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        existing.setUsername(user.getUsername());
+        existing.setEmail(user.getEmail());
+        existing.setRoleId(user.getRoleId());
+        existing.setStatus(user.isStatus());
+        return userRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        userRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/util/ResponsePageDataEntity.java
+++ b/backend/src/main/java/com/platform/marketing/util/ResponsePageDataEntity.java
@@ -4,14 +4,14 @@ import java.util.List;
 
 public class ResponsePageDataEntity<T> {
     private long total;
-    private List<T> list;
+    private List<T> rows;
 
     public ResponsePageDataEntity() {
     }
 
-    public ResponsePageDataEntity(long total, List<T> list) {
+    public ResponsePageDataEntity(long total, List<T> rows) {
         this.total = total;
-        this.list = list;
+        this.rows = rows;
     }
 
     public long getTotal() {
@@ -22,11 +22,11 @@ public class ResponsePageDataEntity<T> {
         this.total = total;
     }
 
-    public List<T> getList() {
-        return list;
+    public List<T> getRows() {
+        return rows;
     }
 
-    public void setList(List<T> list) {
-        this.list = list;
+    public void setRows(List<T> rows) {
+        this.rows = rows;
     }
 }

--- a/frontend/src/assets/css/permission-ui-enhanced.css
+++ b/frontend/src/assets/css/permission-ui-enhanced.css
@@ -1,0 +1,31 @@
+/* 权限管理模块统一样式 */
+.page-card {
+  padding: 20px;
+  margin-bottom: 20px;
+  background: #fff;
+}
+
+.toolbar.mb-4 {
+  margin-bottom: 16px;
+}
+
+.toolbar.gap-2 > * + * {
+  margin-left: 8px;
+}
+
+.page-card .el-table--small .cell {
+  padding: 6px 8px;
+  font-size: 14px;
+}
+
+.page-dialog .el-dialog__title {
+  font-weight: 600;
+}
+
+.page-dialog .el-form-item {
+  margin-bottom: 16px;
+}
+
+.text-right {
+  text-align: right;
+}

--- a/frontend/src/store/permission.js
+++ b/frontend/src/store/permission.js
@@ -22,7 +22,7 @@ export const usePermissionStore = defineStore('permission', {
       }).then(res => {
         this.loading = false
         if (res.code === 0) {
-          this.list = res.data.list
+          this.list = res.data.rows
           this.total = res.data.total
         }
       }).catch(() => {

--- a/frontend/src/views/UserManagement.vue
+++ b/frontend/src/views/UserManagement.vue
@@ -60,7 +60,7 @@ function loadRoles(){
 function fetchList() {
   fetchUsers ({ page: page.value - 1, size, ...search }).then(res => {
     if(res.code===0){
-      list.value=res.data.list
+      list.value=res.data.rows
       total.value=res.data.total
     }
   })

--- a/frontend/src/views/permission/PermissionListTab.vue
+++ b/frontend/src/views/permission/PermissionListTab.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <div class="toolbar mb-3 flex justify-between items-center">
+  <el-card class="page-card">
+    <div class="toolbar mb-4 flex justify-between items-center gap-2">
       <div class="filters flex items-center gap-2">
         <el-input v-model="searchKeyword" placeholder="权限名称/编码" clearable style="width: 220px" />
         <el-select v-model="searchType" placeholder="类型" clearable style="width: 120px">
@@ -14,7 +14,7 @@
         </el-select>
         <el-button type="primary" icon="Search" @click="fetchData">搜索</el-button>
       </div>
-      <div class="actions">
+      <div class="actions flex gap-2">
         <el-button type="danger" icon="Delete" :disabled="!selection.length" @click="handleBatchDelete">批量删除</el-button>
         <el-button type="primary" icon="Plus" @click="openDialog">新增权限</el-button>
       </div>
@@ -23,6 +23,7 @@
     <el-table
       :data="permissionList"
       border
+      size="small"
       v-loading="loading"
       style="width: 100%"
       @selection-change="selection = $event"
@@ -37,6 +38,9 @@
             v-model="row.status"
             :active-value="true"
             :inactive-value="false"
+            inline-prompt
+            active-text="启"
+            inactive-text="禁"
             @change="toggleStatus(row)"
           />
         </template>
@@ -49,16 +53,22 @@
       </el-table-column>
     </el-table>
 
-    <el-pagination
-      v-model:current-page="page"
-      v-model:page-size="size"
-      :total="total"
-      layout="total, prev, pager, next"
-      @current-change="fetchData"
-    />
+    <div class="text-right mt-4">
+      <el-pagination
+        background
+        v-model:current-page="page"
+        v-model:page-size="size"
+        :total="total"
+        layout="total, prev, pager, next"
+        @current-change="fetchData"
+      />
+    </div>
 
-    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑权限' : '新建权限'" width="500px">
-      <el-form :model="form" label-width="100px">
+    <el-dialog class="page-dialog" v-model="dialogVisible" width="500px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑权限' : '新建权限' }}</strong>
+      </template>
+      <el-form class="dialog-form" :model="form" label-width="100px">
         <el-form-item label="权限名称">
           <el-input v-model="form.name" />
         </el-form-item>
@@ -84,7 +94,7 @@
           />
         </el-form-item>
         <el-form-item label="状态">
-          <el-switch v-model="form.status" :active-value="true" :inactive-value="false" />
+          <el-switch v-model="form.status" :active-value="true" :inactive-value="false" inline-prompt active-text="启" inactive-text="禁" />
         </el-form-item>
       </el-form>
       <template #footer>
@@ -92,7 +102,7 @@
         <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
-  </div>
+  </el-card>
 </template>
 
 <script setup>
@@ -107,6 +117,7 @@ import {
   updatePermissionStatus,
   deletePermissionsBatch
 } from '../../api/permission'
+import '@/assets/css/permission-ui-enhanced.css'
 
 const permissionList = ref([])
 const total = ref(0)

--- a/frontend/src/views/permission/PermissionTreeTab.vue
+++ b/frontend/src/views/permission/PermissionTreeTab.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="permission-tree-tab">
-    <div class="toolbar mb-3 flex justify-between items-center">
+  <el-card class="page-card">
+    <div class="toolbar mb-4 text-right gap-2">
       <el-button type="primary" icon="Plus" @click="openAddDialog">新增权限</el-button>
     </div>
 
@@ -16,14 +16,19 @@
       <template #default="{ node, data }">
         <span class="tree-node">
           {{ data.name }}（{{ data.code }}）
-          <el-button type="text" size="small" @click.stop="openEditDialog(data)">编辑</el-button>
-          <el-button type="text" size="small" style="color:red;" @click.stop="remove(data.id)">删除</el-button>
+          <span class="actions">
+            <el-button type="text" size="small" @click.stop="openEditDialog(data)">编辑</el-button>
+            <el-button type="text" size="small" style="color:red" @click.stop="remove(data.id)">删除</el-button>
+          </span>
         </span>
       </template>
     </el-tree>
 
-    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑权限' : '新增权限'" width="500px">
-      <el-form :model="form" label-width="100px">
+    <el-dialog class="page-dialog" v-model="dialogVisible" width="500px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑权限' : '新增权限' }}</strong>
+      </template>
+      <el-form class="dialog-form" :model="form" label-width="100px">
         <el-form-item label="权限名称">
           <el-input v-model="form.name" />
         </el-form-item>
@@ -54,7 +59,7 @@
         <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
-  </div>
+  </el-card>
 </template>
 
 <script setup>
@@ -66,6 +71,7 @@ import {
   updatePermission,
   deletePermission
 } from '../../api/permission'
+import '@/assets/css/permission-ui-enhanced.css'
 
 const treeData = ref([])
 const defaultProps = { label: 'name', children: 'children' }

--- a/frontend/src/views/permission/RoleManagementTab.vue
+++ b/frontend/src/views/permission/RoleManagementTab.vue
@@ -1,10 +1,10 @@
 <template>
-  <div>
-    <div class="toolbar mb-3">
+  <el-card class="page-card">
+    <div class="toolbar mb-4 flex gap-2">
       <el-button type="primary" icon="Plus" @click="openDialog">新建角色</el-button>
     </div>
 
-    <el-table :data="roles" border v-loading="loading" style="width: 100%">
+    <el-table :data="roles" border size="small" v-loading="loading" style="width: 100%">
       <el-table-column prop="name" label="角色名称" />
       <el-table-column prop="description" label="角色描述" />
       <el-table-column label="操作" width="180">
@@ -15,8 +15,11 @@
       </el-table-column>
     </el-table>
 
-    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑角色' : '新建角色'" width="600px">
-      <el-form :model="form" label-width="80px">
+    <el-dialog class="page-dialog" v-model="dialogVisible" width="600px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑角色' : '新建角色' }}</strong>
+      </template>
+      <el-form class="dialog-form" :model="form" label-width="80px">
         <el-form-item label="名称">
           <el-input v-model="form.name" />
         </el-form-item>
@@ -40,7 +43,7 @@
         <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
-  </div>
+  </el-card>
 </template>
 
 <script setup>
@@ -51,6 +54,7 @@ import {
   fetchRolePermissions, bindPermissions
 } from '../../api/role'
 import { fetchPermissionTree } from '../../api/permission'
+import '@/assets/css/permission-ui-enhanced.css'
 
 const roles = ref([])
 const loading = ref(false)

--- a/frontend/src/views/permission/UserManagementTab.vue
+++ b/frontend/src/views/permission/UserManagementTab.vue
@@ -1,17 +1,17 @@
 <template>
-  <div>
-    <div class="toolbar mb-3 flex justify-between items-center">
+  <el-card class="page-card">
+    <div class="toolbar mb-4 flex justify-between items-center gap-2">
       <el-input v-model="searchKeyword" placeholder="搜索用户" clearable style="width: 240px" />
       <el-button type="primary" icon="Plus" @click="openDialog">新建用户</el-button>
     </div>
 
-    <el-table :data="userList" border v-loading="loading" style="width: 100%">
+    <el-table :data="userList" border size="small" v-loading="loading" style="width: 100%">
       <el-table-column prop="username" label="用户名" />
       <el-table-column prop="email" label="邮箱" />
       <el-table-column prop="roleName" label="角色" />
       <el-table-column prop="status" label="状态" width="100">
         <template #default="{ row }">
-          <el-switch v-model="row.status" @change="toggleStatus(row)" />
+          <el-switch v-model="row.status" inline-prompt active-text="启" inactive-text="禁" @change="toggleStatus(row)" />
         </template>
       </el-table-column>
       <el-table-column label="操作" width="220">
@@ -23,16 +23,22 @@
       </el-table-column>
     </el-table>
 
-    <el-pagination
-      v-model:current-page="page"
-      v-model:page-size="size"
-      :total="total"
-      layout="total, prev, pager, next"
-      @current-change="fetchData"
-    />
+    <div class="text-right mt-4">
+      <el-pagination
+        background
+        v-model:current-page="page"
+        v-model:page-size="size"
+        :total="total"
+        layout="total, prev, pager, next"
+        @current-change="fetchData"
+      />
+    </div>
 
-    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑用户' : '新建用户'" width="500px">
-      <el-form :model="form" label-width="100px">
+    <el-dialog class="page-dialog" v-model="dialogVisible" width="500px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑用户' : '新建用户' }}</strong>
+      </template>
+      <el-form class="dialog-form" :model="form" label-width="100px">
         <el-form-item label="用户名">
           <el-input v-model="form.username" />
         </el-form-item>
@@ -50,7 +56,7 @@
           </el-select>
         </el-form-item>
         <el-form-item label="状态">
-          <el-switch v-model="form.status" />
+          <el-switch v-model="form.status" inline-prompt active-text="启" inactive-text="禁" />
         </el-form-item>
       </el-form>
 
@@ -59,7 +65,7 @@
         <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
-  </div>
+  </el-card>
 </template>
 
 <script setup>
@@ -70,6 +76,7 @@ import {
   resetUserPassword, updateUserStatus
 } from '../../api/user'
 import { fetchRoles } from '../../api/role'
+import '@/assets/css/permission-ui-enhanced.css'
 
 const userList = ref([])
 const total = ref(0)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- add user entity, repository, service and controller with CRUD endpoints
- update role controller with create and update routes
- allow permission creation via JSON body

## Testing
- `npm run build` *(fails: vite not found)*
- `mvn -f backend/pom.xml package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787d1d8c248326a1196b47f69bcc2d