### PR TITLE
Fix permission evaluator for Spring Security

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/CustomPermissionEvaluator.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomPermissionEvaluator.java
@@ -1,0 +1,29 @@
+package com.platform.marketing.auth;
+
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+
+@Component
+public class CustomPermissionEvaluator implements PermissionEvaluator {
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        if (authentication == null || permission == null) {
+            return false;
+        }
+        String perm = permission.toString();
+        boolean result = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(perm::equals);
+        System.out.println("➡️ Evaluating permission " + perm + " result=" + result);
+        return result;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+        return hasPermission(authentication, targetType, permission);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/auth/JwtFilter.java
+++ b/backend/src/main/java/com/platform/marketing/auth/JwtFilter.java
@@ -47,6 +47,9 @@ public class JwtFilter extends OncePerRequestFilter {
                         userDetails, null, userDetails.getAuthorities());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
+                System.out.println("➡️ Set authentication for " + username);
+            } else {
+                System.out.println("❌ Invalid JWT token");
             }
         }
 

--- a/backend/src/main/java/com/platform/marketing/auth/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/auth/MethodSecurityConfig.java
@@ -1,0 +1,26 @@
+package com.platform.marketing.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    private final PermissionEvaluator permissionEvaluator;
+
+    public MethodSecurityConfig(PermissionEvaluator permissionEvaluator) {
+        this.permissionEvaluator = permissionEvaluator;
+    }
+
+    @Override
+    protected MethodSecurityExpressionHandler createExpressionHandler() {
+        DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+        handler.setPermissionEvaluator(permissionEvaluator);
+        return handler;
+    }
+}


### PR DESCRIPTION
## Summary
- add `CustomPermissionEvaluator` to check authorities from JWT
- register custom evaluator via new `MethodSecurityConfig`
- log auth events in `JwtFilter`

## Testing
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_687dafd7d0ac8326a8223a7c088d42c0