### PR TITLE
Fix permission evaluator for Spring Security

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/CustomPermissionEvaluator.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomPermissionEvaluator.java
@@ -1,0 +1,33 @@
+package com.platform.marketing.auth;
+
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+
+@Component
+public class CustomPermissionEvaluator implements PermissionEvaluator {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomPermissionEvaluator.class);
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        if (authentication == null || permission == null) {
+            return false;
+        }
+        String perm = permission.toString();
+        boolean result = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(perm::equals);
+        log.debug("Evaluate permission '{}' result={}", perm, result);
+        return result;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+        return hasPermission(authentication, targetType, permission);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/auth/JwtFilter.java
+++ b/backend/src/main/java/com/platform/marketing/auth/JwtFilter.java
@@ -5,6 +5,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -18,6 +20,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private static final Logger log = LoggerFactory.getLogger(JwtFilter.class);
 
     public JwtFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
         this.jwtUtil = jwtUtil;
@@ -29,7 +32,7 @@ public class JwtFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String path = request.getRequestURI();
-        System.out.println("➡️ JWT Filter URI: " + path);
+        log.debug("JWT Filter URI: {}", path);
 
         // ✅ 放行登录接口
         if ("/v1/auth/login".equals(path)) {
@@ -47,6 +50,9 @@ public class JwtFilter extends OncePerRequestFilter {
                         userDetails, null, userDetails.getAuthorities());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
+                log.debug("Set authentication for {}", username);
+            } else {
+                log.debug("Invalid JWT token");
             }
         }
 

--- a/backend/src/main/java/com/platform/marketing/auth/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/auth/MethodSecurityConfig.java
@@ -1,0 +1,26 @@
+package com.platform.marketing.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    private final PermissionEvaluator permissionEvaluator;
+
+    public MethodSecurityConfig(PermissionEvaluator permissionEvaluator) {
+        this.permissionEvaluator = permissionEvaluator;
+    }
+
+    @Override
+    protected MethodSecurityExpressionHandler createExpressionHandler() {
+        DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+        handler.setPermissionEvaluator(permissionEvaluator);
+        return handler;
+    }
+}


### PR DESCRIPTION
## Summary
- add `CustomPermissionEvaluator` to check authorities from JWT
- register custom evaluator via new `MethodSecurityConfig`
- log auth events with slf4j in `JwtFilter` and `CustomPermissionEvaluator`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dafd7d0ac8326a8223a7c088d42c0