### PR TITLE
Fix MethodSecurityConfig loading

### DIFF
--- a/backend/src/main/java/com/platform/marketing/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/MethodSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.platform.marketing.auth;
+package com.platform.marketing;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.PermissionEvaluator;
@@ -6,15 +6,21 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import com.platform.marketing.auth.CustomPermissionEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
+    private static final Logger log = LoggerFactory.getLogger(MethodSecurityConfig.class);
+
     private final PermissionEvaluator permissionEvaluator;
 
     public MethodSecurityConfig(PermissionEvaluator permissionEvaluator) {
         this.permissionEvaluator = permissionEvaluator;
+        log.info("\uD83D\uDFE2 MethodSecurityConfig 初始化了！");
     }
 
     @Override


### PR DESCRIPTION
## Summary
- move `MethodSecurityConfig` into the root `com.platform.marketing` package so it's loaded
- log initialization of `MethodSecurityConfig`

## Testing
- `apt-get update` *(fails: repository forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687dbbb9f10c83269318fd3b35902bb1