### PR TITLE
Refactor permission module structure

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,6 +1,32 @@
 <template>
   <div class="system-container">
-    <SidebarMenu class="sidebar" />
+    <div class="sidebar">
+      <div class="logo">🌍 {{ t('sidebar.brand') }}</div>
+      <el-menu :default-active="activeMenu" @select="handleSelect">
+        <el-menu-item
+          v-for="item in otherMenus"
+          :key="item.path"
+          :index="item.path"
+        >
+          <el-icon><component :is="item.icon" /></el-icon>
+          <span>{{ item.title }}</span>
+        </el-menu-item>
+        <el-sub-menu index="system">
+          <template #title>
+            <el-icon><Setting /></el-icon>
+            <span>系统管理</span>
+          </template>
+          <el-menu-item
+            v-for="item in systemMenus"
+            :key="item.path"
+            :index="item.path"
+          >
+            <el-icon><component :is="item.icon" /></el-icon>
+            <span>{{ item.title }}</span>
+          </el-menu-item>
+        </el-sub-menu>
+      </el-menu>
+    </div>
     <div class="main-content">
       <HeaderBar class="header" />
       <div class="content-area">
@@ -11,6 +37,62 @@
 </template>
 
 <script setup>
-import SidebarMenu from '../components/SidebarMenu.vue'
+import { ref, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import HeaderBar from '../components/HeaderBar.vue'
+import {
+  Odometer,
+  Promotion,
+  Bell,
+  QuestionFilled,
+  Search,
+  User,
+  Message,
+  Share,
+  Clock,
+  View,
+  DataLine,
+  Lock,
+  UserFilled,
+  Setting,
+  EditPen,
+} from '@element-plus/icons-vue'
+
+const router = useRouter()
+const route = useRoute()
+const { t } = useI18n()
+
+const menuList = [
+  { path: '/dashboard', title: '控制台', icon: Odometer },
+  { path: '/campaign-center', title: '营销活动', icon: Promotion },
+  { path: '/notifications', title: '通知中心', icon: Bell },
+  { path: '/help-center', title: '帮助中心', icon: QuestionFilled },
+  { path: '/customer-crawl', title: '客户采集', icon: Search },
+  { path: '/customer-manage', title: '客户管理', icon: User },
+  { path: '/email-marketing', title: '邮件营销', icon: Message },
+  { path: '/social-media', title: '社交营销', icon: Share },
+  { path: '/task-schedule', title: '任务调度', icon: Clock },
+  { path: '/behavior-track', title: '行为追踪', icon: View },
+  { path: '/reports', title: '报表统计', icon: DataLine },
+  { path: '/permission', title: '权限管理', icon: Lock },
+  { path: '/settings', title: '系统设置', icon: Setting },
+  { path: '/content-generate', title: '内容生成', icon: EditPen },
+]
+
+const systemPaths = ['/permission', '/settings']
+const systemMenus = menuList.filter((m) => systemPaths.includes(m.path))
+const otherMenus = menuList.filter((m) => !systemPaths.includes(m.path))
+
+const activeMenu = ref(route.path)
+watch(
+  () => route.path,
+  (val) => {
+    activeMenu.value = val
+  }
+)
+
+function handleSelect(index) {
+  router.push(index)
+}
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,8 +6,6 @@ import MainLayout from '../layouts/MainLayout.vue'
 import DashboardView from '../views/DashboardView.vue'
 import CustomerCrawlView from '../views/CustomerCrawlView.vue'
 import PermissionView from '../views/PermissionView.vue'
-import RoleManagement from '../views/RoleManagement.vue'
-import UserManagement from '../views/UserManagement.vue'
 import CustomerManageView from '../views/CustomerManageView.vue'
 import SettingsView from '../views/SettingsView.vue'
 import ContentGenerateView from '../views/ContentGenerateView.vue'
@@ -29,8 +27,6 @@ const routes = [
       { path: 'customer-crawl', name: 'CustomerCrawl', component: CustomerCrawlView },
       { path: 'customer-manage', name: 'CustomerManage', component: CustomerManageView },
       { path: 'permission', name: 'Permission', component: PermissionView },
-      { path: 'roles', name: 'RoleManagement', component: RoleManagement },
-      { path: 'users', name: 'UserManagement', component: UserManagement },
       { path: 'settings', name: 'Settings', component: SettingsView },
       { path: 'content-generate', name: 'ContentGenerate', component: ContentGenerateView },
       { path: 'email-marketing', name: 'EmailMarketing', component: EmailMarketingView },

--- a/frontend/src/views/PermissionConfig.vue
+++ b/frontend/src/views/PermissionConfig.vue
@@ -1,0 +1,10 @@
+<template>
+  <PermissionTreeTab />
+</template>
+
+<script setup>
+import PermissionTreeTab from './permission/PermissionTreeTab.vue'
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/PermissionView.vue
+++ b/frontend/src/views/PermissionView.vue
@@ -1,42 +1,26 @@
 <template>
-  <div class="page-wrapper">
-    <el-breadcrumb separator="/" class="mb-3">
-      <el-breadcrumb-item>系统设置</el-breadcrumb-item>
-      <el-breadcrumb-item>权限管理</el-breadcrumb-item>
-    </el-breadcrumb>
-    <el-tabs v-model="active" type="card">
-      <el-tab-pane label="角色管理" name="roles">
-        <RoleManagementTab v-if="active==='roles'" />
-      </el-tab-pane>
-      <el-tab-pane label="权限列表" name="list">
-        <PermissionListTab v-if="active==='list'" />
-      </el-tab-pane>
-      <el-tab-pane label="用户管理" name="users">
-        <UserManagementTab v-if="active==='users'" />
-      </el-tab-pane>
-      <el-tab-pane label="权限配置" name="permissions">
-        <PermissionTreeTab v-if="active==='permissions'" />
-      </el-tab-pane>
-    </el-tabs>
-  </div>
+  <el-tabs v-model="activeTab">
+    <el-tab-pane label="角色管理" name="roles">
+      <RoleManagement />
+    </el-tab-pane>
+    <el-tab-pane label="用户管理" name="users">
+      <UserManagement />
+    </el-tab-pane>
+    <el-tab-pane label="权限配置" name="permission-setting">
+      <PermissionConfig />
+    </el-tab-pane>
+  </el-tabs>
 </template>
 
 <script setup>
 import { ref } from 'vue'
-import RoleManagementTab from './permission/RoleManagementTab.vue'
-import PermissionListTab from './permission/PermissionListTab.vue'
-import UserManagementTab from './permission/UserManagementTab.vue'
-import PermissionTreeTab from './permission/PermissionTreeTab.vue'
+import RoleManagement from './RoleManagement.vue'
+import UserManagement from './UserManagement.vue'
+import PermissionConfig from './PermissionConfig.vue'
 
-const active = ref('roles')
+const activeTab = ref('roles')
 </script>
 
 <style scoped>
-.page-wrapper {
-  padding: 20px;
-}
-.mb-3 {
-  margin-bottom: 15px;
-}
 </style>
 


### PR DESCRIPTION
## Summary
- consolidate permission features under a single `/permission` route
- update sidebar menu to only show `权限管理` entry
- remove obsolete `roles` and `users` routes
- create `PermissionConfig.vue` and simplify `PermissionView.vue`

## Testing
- `npm install --silent` *(fails: network disabled)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e04834df08326b006f157870da5f0