### PR TITLE
Implement custom MethodSecurityExpressionRoot and handler

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionHandler.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionHandler.java
@@ -1,0 +1,24 @@
+package com.platform.marketing.auth;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Method security expression handler creating {@link CustomMethodSecurityExpressionRoot}.
+ */
+@Component
+public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
+
+    @Override
+    protected MethodSecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication,
+                                                                              MethodInvocation invocation) {
+        CustomMethodSecurityExpressionRoot root = new CustomMethodSecurityExpressionRoot(authentication);
+        root.setPermissionEvaluator(getPermissionEvaluator());
+        root.setTrustResolver(getTrustResolver());
+        root.setRoleHierarchy(getRoleHierarchy());
+        return root;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
@@ -1,0 +1,24 @@
+package com.platform.marketing.auth;
+
+import org.springframework.security.access.expression.method.MethodSecurityExpressionRoot;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Custom expression root exposing {@code hasPermission(String)} to SpEL.
+ */
+public class CustomMethodSecurityExpressionRoot extends MethodSecurityExpressionRoot {
+
+    public CustomMethodSecurityExpressionRoot(Authentication authentication) {
+        super(authentication);
+    }
+
+    /**
+     * Check permission string using the configured {@code PermissionEvaluator}.
+     *
+     * @param permission permission name
+     * @return {@code true} if the current user has the permission
+     */
+    public boolean hasPermission(String permission) {
+        return permission != null && hasPermission((Object) null, permission);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
@@ -1,8 +1,8 @@
 package com.platform.marketing.config;
 
 import com.platform.marketing.auth.CustomPermissionEvaluator;
+import com.platform.marketing.auth.CustomMethodSecurityExpressionHandler;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 
@@ -17,9 +17,10 @@ public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
     }
 
     @Override
-    protected DefaultMethodSecurityExpressionHandler createExpressionHandler() {
-        DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+    protected CustomMethodSecurityExpressionHandler createExpressionHandler() {
+        CustomMethodSecurityExpressionHandler handler = new CustomMethodSecurityExpressionHandler();
         handler.setPermissionEvaluator(permissionEvaluator);
+        setExpressionHandler(handler);
         return handler;
     }
 }


### PR DESCRIPTION
## Summary
- add a `CustomMethodSecurityExpressionRoot` exposing `hasPermission(String)`
- implement `CustomMethodSecurityExpressionHandler` to use the custom root
- wire the handler in `MethodSecurityConfig`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f0cab18948326b243ce56b8d142a8