### PR TITLE
Fix custom method security evaluator

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
@@ -1,6 +1,7 @@
 package com.platform.marketing.auth;
 
 import org.springframework.security.access.expression.SecurityExpressionRoot;
+import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 
 import org.springframework.security.core.Authentication;
@@ -14,10 +15,25 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
     private Object filterObject;
     private Object returnObject;
     private Object target;
+    private PermissionEvaluator permissionEvaluator;
 
 
     public CustomMethodSecurityExpressionRoot(Authentication authentication) {
         super(authentication);
+    }
+
+    /**
+     * Exposes the configured {@link PermissionEvaluator} because
+     * {@link SecurityExpressionRoot#getPermissionEvaluator()} is protected.
+     */
+    public PermissionEvaluator getPermissionEvaluator() {
+        return permissionEvaluator;
+    }
+
+    @Override
+    public void setPermissionEvaluator(PermissionEvaluator permissionEvaluator) {
+        super.setPermissionEvaluator(permissionEvaluator);
+        this.permissionEvaluator = permissionEvaluator;
     }
 
     /**
@@ -27,7 +43,10 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
      * @return {@code true} if the current user has the permission
      */
     public boolean hasPermission(String permission) {
-        return permission != null && hasPermission((Object) null, permission);
+        if (permission == null || permissionEvaluator == null) {
+            return false;
+        }
+        return permissionEvaluator.hasPermission(this.getAuthentication(), null, permission);
     }
 
     @Override
@@ -35,7 +54,6 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
         return target;
     }
 
-    @Override
     public void setThis(Object target) {
         this.target = target;
     }

--- a/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
@@ -11,16 +11,17 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
     private final CustomPermissionEvaluator permissionEvaluator;
+    private final CustomMethodSecurityExpressionHandler expressionHandler;
 
-    public MethodSecurityConfig(CustomPermissionEvaluator permissionEvaluator) {
+    public MethodSecurityConfig(CustomPermissionEvaluator permissionEvaluator,
+                               CustomMethodSecurityExpressionHandler expressionHandler) {
         this.permissionEvaluator = permissionEvaluator;
+        this.expressionHandler = expressionHandler;
     }
 
     @Override
     protected CustomMethodSecurityExpressionHandler createExpressionHandler() {
-        CustomMethodSecurityExpressionHandler handler = new CustomMethodSecurityExpressionHandler();
-        handler.setPermissionEvaluator(permissionEvaluator);
-        setExpressionHandler(handler);
-        return handler;
+        expressionHandler.setPermissionEvaluator(permissionEvaluator);
+        return expressionHandler;
     }
 }


### PR DESCRIPTION
## Summary
- register `CustomMethodSecurityExpressionHandler` through `MethodSecurityConfig`
- expose permission evaluator in `CustomMethodSecurityExpressionRoot`
- document why permission evaluator is stored

## Testing
- ❌ `apt-get update` *(failed to fetch packages: 403 Forbidden)*
- ❌ `mvn -q -DskipTests package` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f15784ae08326b7c286376c6f771d