### PR TITLE
Fix custom method security evaluator

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionHandler.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionHandler.java
@@ -7,19 +7,27 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
- * Method security expression handler creating {@link CustomMethodSecurityExpressionRoot}.
+ * Custom handler using {@link CustomMethodSecurityExpressionRoot} and the
+ * injected {@link CustomPermissionEvaluator}.
  */
 @Component
-
 public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
+
+    private final CustomPermissionEvaluator permissionEvaluator;
+
+    public CustomMethodSecurityExpressionHandler(CustomPermissionEvaluator permissionEvaluator) {
+        this.permissionEvaluator = permissionEvaluator;
+        setPermissionEvaluator(permissionEvaluator);
+    }
 
     @Override
     protected MethodSecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication,
                                                                               MethodInvocation invocation) {
         CustomMethodSecurityExpressionRoot root = new CustomMethodSecurityExpressionRoot(authentication);
-        root.setPermissionEvaluator(getPermissionEvaluator());
+        root.setPermissionEvaluator(this.permissionEvaluator);
         root.setTrustResolver(getTrustResolver());
         root.setRoleHierarchy(getRoleHierarchy());
+        root.setThis(invocation.getThis());
         return root;
     }
 }

--- a/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
+++ b/backend/src/main/java/com/platform/marketing/auth/CustomMethodSecurityExpressionRoot.java
@@ -2,47 +2,40 @@ package com.platform.marketing.auth;
 
 import org.springframework.security.access.expression.SecurityExpressionRoot;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
-
 import org.springframework.security.core.Authentication;
 
 /**
- * Custom expression root exposing {@code hasPermission(String)} to SpEL.
+ * Custom expression root providing {@code hasPermission(String)} support.
  */
-public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
-        implements MethodSecurityExpressionOperations {
+public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot implements MethodSecurityExpressionOperations {
 
     private Object filterObject;
     private Object returnObject;
     private Object target;
-
 
     public CustomMethodSecurityExpressionRoot(Authentication authentication) {
         super(authentication);
     }
 
     /**
-     * Check permission string using the configured {@code PermissionEvaluator}.
+     * Evaluate a permission against the current {@link Authentication}.
      *
-     * @param permission permission name
-     * @return {@code true} if the current user has the permission
+     * @param permission permission identifier
+     * @return {@code true} if the permission is granted
      */
     public boolean hasPermission(String permission) {
-        return permission != null && hasPermission((Object) null, permission);
+        if (permission == null) {
+            return false;
+        }
+        return getPermissionEvaluator().hasPermission(getAuthentication(), null, permission);
     }
 
-    @Override
-    public Object getThis() {
-        return target;
-    }
-
-    @Override
-    public void setThis(Object target) {
-        this.target = target;
-    }
-
+    // ------------------------------------------------------------------
+    // Methods from {@link MethodSecurityExpressionOperations}
+    // ------------------------------------------------------------------
     @Override
     public Object getFilterObject() {
-        return filterObject;
+        return this.filterObject;
     }
 
     @Override
@@ -52,7 +45,7 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
 
     @Override
     public Object getReturnObject() {
-        return returnObject;
+        return this.returnObject;
     }
 
     @Override
@@ -60,4 +53,13 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
         this.returnObject = returnObject;
     }
 
+    @Override
+    public Object getThis() {
+        return this.target;
+    }
+
+    @Override
+    public void setThis(Object target) {
+        this.target = target;
+    }
 }

--- a/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
@@ -11,16 +11,17 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
     private final CustomPermissionEvaluator permissionEvaluator;
+    private final CustomMethodSecurityExpressionHandler expressionHandler;
 
-    public MethodSecurityConfig(CustomPermissionEvaluator permissionEvaluator) {
+    public MethodSecurityConfig(CustomPermissionEvaluator permissionEvaluator,
+                               CustomMethodSecurityExpressionHandler expressionHandler) {
         this.permissionEvaluator = permissionEvaluator;
+        this.expressionHandler = expressionHandler;
     }
 
     @Override
     protected CustomMethodSecurityExpressionHandler createExpressionHandler() {
-        CustomMethodSecurityExpressionHandler handler = new CustomMethodSecurityExpressionHandler();
-        handler.setPermissionEvaluator(permissionEvaluator);
-        setExpressionHandler(handler);
-        return handler;
+        expressionHandler.setPermissionEvaluator(permissionEvaluator);
+        return expressionHandler;
     }
 }


### PR DESCRIPTION
## Summary
- register `CustomMethodSecurityExpressionHandler` through `MethodSecurityConfig`
- expose permission evaluator in `CustomMethodSecurityExpressionRoot`
- document why permission evaluator is stored

## Testing
- ❌ `apt-get update` *(failed to fetch packages: 403 Forbidden)*
- ❌ `mvn -q -DskipTests package` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f15784ae08326b7c286376c6f771d