### PR TITLE
Implement user update API

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/UserController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/UserController.java
@@ -34,6 +34,13 @@ public class UserController {
         return ResponseEntity.success(userService.create(user));
     }
 
+    @PutMapping("/{id}")
+    @PreAuthorize("hasPermission('user:update')")
+    public ResponseEntity<User> update(@PathVariable String id, @RequestBody User user) {
+        user.setId(id);
+        return ResponseEntity.success(userService.update(user));
+    }
+
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasPermission('user:delete')")

--- a/backend/src/main/java/com/platform/marketing/entity/User.java
+++ b/backend/src/main/java/com/platform/marketing/entity/User.java
@@ -22,6 +22,8 @@ public class User {
 
     private String email;
 
+    private boolean status = true;
+
     @Column(name = "create_time")
     private LocalDateTime createTime;
 
@@ -43,6 +45,9 @@ public class User {
 
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
+
+    public boolean isStatus() { return status; }
+    public void setStatus(boolean status) { this.status = status; }
 
     public LocalDateTime getCreateTime() { return createTime; }
     public void setCreateTime(LocalDateTime createTime) { this.createTime = createTime; }

--- a/backend/src/main/java/com/platform/marketing/service/UserService.java
+++ b/backend/src/main/java/com/platform/marketing/service/UserService.java
@@ -8,6 +8,7 @@ public interface UserService {
     Page<User> search(String keyword, Pageable pageable);
     User create(User user);
     User update(String id, User user);
+    User update(User user);
     void delete(String id);
     User findByUsername(String username);
 

--- a/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
@@ -44,6 +44,18 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         existing.setUsername(user.getUsername());
         existing.setEmail(user.getEmail());
+        existing.setStatus(user.isStatus());
+        return userRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public User update(User user) {
+        User existing = userRepository.findById(user.getId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        existing.setUsername(user.getUsername());
+        existing.setEmail(user.getEmail());
+        existing.setStatus(user.isStatus());
         return userRepository.save(existing);
     }
 


### PR DESCRIPTION
## Summary
- add a new `status` field to `User`
- expose PUT `/v1/users/{id}` endpoint to update a user
- support updating username/email/status in `UserService`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3a1312e0832681c5766b0861f12d