### PR TITLE
Implement user update API

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/UserController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/UserController.java
@@ -34,6 +34,36 @@ public class UserController {
         return ResponseEntity.success(userService.create(user));
     }
 
+    @PutMapping("/{id}")
+    @PreAuthorize("hasPermission('user:update')")
+    public ResponseEntity<User> update(@PathVariable String id, @RequestBody User user) {
+        user.setId(id);
+        return ResponseEntity.success(userService.update(user));
+    }
+
+    @PostMapping("/update-status")
+    @PreAuthorize("hasPermission('user:update')")
+    public ResponseEntity<Void> updateStatus(@RequestBody java.util.Map<String, Object> body) {
+        String id = (String) body.get("id");
+        Boolean status = (Boolean) body.get("status");
+        if (id == null || status == null) {
+            return ResponseEntity.fail(400, "id and status required");
+        }
+        userService.updateStatus(id, status);
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/{id}/reset-password")
+    @PreAuthorize("hasPermission('user:reset-password')")
+    public ResponseEntity<Void> resetPassword(@PathVariable String id, @RequestBody java.util.Map<String, String> body) {
+        String password = body.get("password");
+        if (password == null) {
+            return ResponseEntity.fail(400, "password required");
+        }
+        userService.resetPassword(id, password);
+        return ResponseEntity.success(null);
+    }
+
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasPermission('user:delete')")

--- a/backend/src/main/java/com/platform/marketing/entity/User.java
+++ b/backend/src/main/java/com/platform/marketing/entity/User.java
@@ -22,6 +22,8 @@ public class User {
 
     private String email;
 
+    private boolean status = true;
+
     @Column(name = "create_time")
     private LocalDateTime createTime;
 
@@ -43,6 +45,9 @@ public class User {
 
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
+
+    public boolean isStatus() { return status; }
+    public void setStatus(boolean status) { this.status = status; }
 
     public LocalDateTime getCreateTime() { return createTime; }
     public void setCreateTime(LocalDateTime createTime) { this.createTime = createTime; }

--- a/backend/src/main/java/com/platform/marketing/service/UserService.java
+++ b/backend/src/main/java/com/platform/marketing/service/UserService.java
@@ -8,8 +8,13 @@ public interface UserService {
     Page<User> search(String keyword, Pageable pageable);
     User create(User user);
     User update(String id, User user);
+    User update(User user);
     void delete(String id);
     User findByUsername(String username);
+
+    void updateStatus(String id, Boolean status);
+
+    void resetPassword(String id, String newPassword);
 
     void assignRoles(String userId, java.util.List<String> roleIds);
 

--- a/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/UserServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,11 +19,14 @@ import java.util.List;
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final UserRoleRepository userRoleRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public UserServiceImpl(UserRepository userRepository,
-                           UserRoleRepository userRoleRepository) {
+                           UserRoleRepository userRoleRepository,
+                           PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
         this.userRoleRepository = userRoleRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -41,9 +45,21 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public User update(String id, User user) {
         User existing = userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new RuntimeException("User not found"));
         existing.setUsername(user.getUsername());
         existing.setEmail(user.getEmail());
+        existing.setStatus(user.isStatus());
+        return userRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public User update(User user) {
+        User existing = userRepository.findById(user.getId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        existing.setUsername(user.getUsername());
+        existing.setEmail(user.getEmail());
+        existing.setStatus(user.isStatus());
         return userRepository.save(existing);
     }
 
@@ -79,5 +95,23 @@ public class UserServiceImpl implements UserService {
             ids.add(ur.getId().getRoleId());
         }
         return ids;
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(String id, Boolean status) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        user.setStatus(status);
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void resetPassword(String id, String newPassword) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Summary
- expose PUT `/v1/users/{id}` for editing a user
- allow updating username, email, and status
- add endpoints for enabling/disabling a user and resetting password
- return a runtime exception when the user is not found

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3a1312e0832681c5766b0861f12d