### PR TITLE
Implement menu module API

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/MenuController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/MenuController.java
@@ -1,0 +1,84 @@
+package com.platform.marketing.controller;
+
+import com.platform.marketing.dto.MenuTreeNode;
+import com.platform.marketing.entity.Menu;
+import com.platform.marketing.service.MenuService;
+import com.platform.marketing.util.ResponseEntity;
+import com.platform.marketing.util.ResponsePageDataEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/menus")
+public class MenuController {
+
+    private final MenuService menuService;
+
+    public MenuController(MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @GetMapping("/tree")
+    public ResponseEntity<List<MenuTreeNode>> tree() {
+        return ResponseEntity.success(menuService.getTree());
+    }
+
+    @GetMapping
+    @PreAuthorize("hasPermission('menu:view')")
+    public ResponseEntity<ResponsePageDataEntity<Menu>> list(@RequestParam(defaultValue = "") String keyword,
+                                                             @RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "10") int size) {
+        Page<Menu> p = menuService.search(keyword, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasPermission('menu:view')")
+    public ResponseEntity<Menu> get(@PathVariable String id) {
+        return menuService.findById(id)
+                .map(ResponseEntity::success)
+                .orElse(ResponseEntity.fail(404, "Not Found"));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasPermission('menu:create')")
+    public ResponseEntity<Menu> create(@RequestBody Menu menu) {
+        if (menu.getId() == null || menu.getId().isEmpty()) {
+            menu.setId(java.util.UUID.randomUUID().toString());
+        }
+        return ResponseEntity.success(menuService.create(menu));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasPermission('menu:update')")
+    public ResponseEntity<Menu> update(@PathVariable String id, @RequestBody Menu menu) {
+        return ResponseEntity.success(menuService.update(id, menu));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasPermission('menu:delete')")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        try {
+            menuService.delete(id);
+            return ResponseEntity.success(null);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.fail(400, e.getMessage());
+        }
+    }
+
+    @PostMapping("/update-status")
+    @PreAuthorize("hasPermission('menu:status')")
+    public ResponseEntity<Void> updateStatus(@RequestBody java.util.Map<String, Object> body) {
+        String id = (String) body.get("id");
+        Boolean status = (Boolean) body.get("status");
+        if (id == null || status == null) {
+            return ResponseEntity.fail(400, "id and status required");
+        }
+        menuService.updateStatus(id, status);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/dto/MenuTreeNode.java
+++ b/backend/src/main/java/com/platform/marketing/dto/MenuTreeNode.java
@@ -1,0 +1,53 @@
+package com.platform.marketing.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MenuTreeNode {
+    private String id;
+    private String name;
+    private String parentId;
+    private String path;
+    private String icon;
+    private Integer orderNum;
+    private String permission;
+    private Boolean status;
+    private String type;
+    private String component;
+    private Boolean keepAlive;
+    private Boolean external;
+    private Boolean hidden;
+    private String remark;
+    private List<MenuTreeNode> children = new ArrayList<>();
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getParentId() { return parentId; }
+    public void setParentId(String parentId) { this.parentId = parentId; }
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+    public String getIcon() { return icon; }
+    public void setIcon(String icon) { this.icon = icon; }
+    public Integer getOrderNum() { return orderNum; }
+    public void setOrderNum(Integer orderNum) { this.orderNum = orderNum; }
+    public String getPermission() { return permission; }
+    public void setPermission(String permission) { this.permission = permission; }
+    public Boolean getStatus() { return status; }
+    public void setStatus(Boolean status) { this.status = status; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public String getComponent() { return component; }
+    public void setComponent(String component) { this.component = component; }
+    public Boolean getKeepAlive() { return keepAlive; }
+    public void setKeepAlive(Boolean keepAlive) { this.keepAlive = keepAlive; }
+    public Boolean getExternal() { return external; }
+    public void setExternal(Boolean external) { this.external = external; }
+    public Boolean getHidden() { return hidden; }
+    public void setHidden(Boolean hidden) { this.hidden = hidden; }
+    public String getRemark() { return remark; }
+    public void setRemark(String remark) { this.remark = remark; }
+    public List<MenuTreeNode> getChildren() { return children; }
+    public void setChildren(List<MenuTreeNode> children) { this.children = children; }
+}

--- a/backend/src/main/java/com/platform/marketing/entity/Menu.java
+++ b/backend/src/main/java/com/platform/marketing/entity/Menu.java
@@ -1,0 +1,88 @@
+package com.platform.marketing.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "sys_menu")
+public class Menu {
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    private String name;
+
+    @Column(name = "parent_id", length = 36)
+    private String parentId;
+
+    private String path;
+
+    private String icon;
+
+    @Column(name = "order_num")
+    private Integer orderNum;
+
+    private String permission;
+
+    private Boolean status = true;
+
+    private String type; // menu, button
+
+    private String component;
+
+    @Column(name = "keep_alive")
+    private Boolean keepAlive;
+
+    @Column(name = "is_external")
+    private Boolean external;
+
+    private Boolean hidden;
+
+    private String remark;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getParentId() { return parentId; }
+    public void setParentId(String parentId) { this.parentId = parentId; }
+
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+
+    public String getIcon() { return icon; }
+    public void setIcon(String icon) { this.icon = icon; }
+
+    public Integer getOrderNum() { return orderNum; }
+    public void setOrderNum(Integer orderNum) { this.orderNum = orderNum; }
+
+    public String getPermission() { return permission; }
+    public void setPermission(String permission) { this.permission = permission; }
+
+    public Boolean getStatus() { return status; }
+    public void setStatus(Boolean status) { this.status = status; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getComponent() { return component; }
+    public void setComponent(String component) { this.component = component; }
+
+    public Boolean getKeepAlive() { return keepAlive; }
+    public void setKeepAlive(Boolean keepAlive) { this.keepAlive = keepAlive; }
+
+    public Boolean getExternal() { return external; }
+    public void setExternal(Boolean external) { this.external = external; }
+
+    public Boolean getHidden() { return hidden; }
+    public void setHidden(Boolean hidden) { this.hidden = hidden; }
+
+    public String getRemark() { return remark; }
+    public void setRemark(String remark) { this.remark = remark; }
+}

--- a/backend/src/main/java/com/platform/marketing/repository/MenuRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/MenuRepository.java
@@ -1,0 +1,22 @@
+package com.platform.marketing.repository;
+
+import com.platform.marketing.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, String> {
+
+    boolean existsByParentId(String parentId);
+
+    @Query("SELECT m FROM Menu m WHERE (:keyword = '' OR lower(m.name) LIKE lower(concat('%', :keyword, '%')))")
+    Page<Menu> search(@Param("keyword") String keyword, Pageable pageable);
+
+    List<Menu> findByParentId(String parentId);
+}

--- a/backend/src/main/java/com/platform/marketing/service/MenuService.java
+++ b/backend/src/main/java/com/platform/marketing/service/MenuService.java
@@ -1,0 +1,19 @@
+package com.platform.marketing.service;
+
+import com.platform.marketing.dto.MenuTreeNode;
+import com.platform.marketing.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MenuService {
+    Page<Menu> search(String keyword, Pageable pageable);
+    Optional<Menu> findById(String id);
+    Menu create(Menu menu);
+    Menu update(String id, Menu menu);
+    void delete(String id);
+    void updateStatus(String id, Boolean status);
+    List<MenuTreeNode> getTree();
+}

--- a/backend/src/main/java/com/platform/marketing/service/impl/MenuServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/MenuServiceImpl.java
@@ -1,0 +1,120 @@
+package com.platform.marketing.service.impl;
+
+import com.platform.marketing.dto.MenuTreeNode;
+import com.platform.marketing.entity.Menu;
+import com.platform.marketing.repository.MenuRepository;
+import com.platform.marketing.service.MenuService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+public class MenuServiceImpl implements MenuService {
+
+    private final MenuRepository menuRepository;
+
+    public MenuServiceImpl(MenuRepository menuRepository) {
+        this.menuRepository = menuRepository;
+    }
+
+    @Override
+    public Page<Menu> search(String keyword, Pageable pageable) {
+        if (keyword == null) keyword = "";
+        return menuRepository.search(keyword, pageable);
+    }
+
+    @Override
+    public Optional<Menu> findById(String id) {
+        return menuRepository.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public Menu create(Menu menu) {
+        return menuRepository.save(menu);
+    }
+
+    @Override
+    @Transactional
+    public Menu update(String id, Menu menu) {
+        Menu existing = menuRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Menu not found"));
+        existing.setName(menu.getName());
+        existing.setParentId(menu.getParentId());
+        existing.setPath(menu.getPath());
+        existing.setIcon(menu.getIcon());
+        existing.setOrderNum(menu.getOrderNum());
+        existing.setPermission(menu.getPermission());
+        existing.setStatus(menu.getStatus());
+        existing.setType(menu.getType());
+        existing.setComponent(menu.getComponent());
+        existing.setKeepAlive(menu.getKeepAlive());
+        existing.setExternal(menu.getExternal());
+        existing.setHidden(menu.getHidden());
+        existing.setRemark(menu.getRemark());
+        return menuRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        if (menuRepository.existsByParentId(id)) {
+            throw new IllegalStateException("Menu has children");
+        }
+        menuRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(String id, Boolean status) {
+        Menu menu = menuRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Menu not found"));
+        menu.setStatus(status);
+        menuRepository.save(menu);
+    }
+
+    @Override
+    public List<MenuTreeNode> getTree() {
+        List<Menu> all = menuRepository.findAll();
+        Map<String, MenuTreeNode> map = new HashMap<>();
+        for (Menu m : all) {
+            MenuTreeNode node = new MenuTreeNode();
+            node.setId(m.getId());
+            node.setName(m.getName());
+            node.setParentId(m.getParentId());
+            node.setPath(m.getPath());
+            node.setIcon(m.getIcon());
+            node.setOrderNum(m.getOrderNum());
+            node.setPermission(m.getPermission());
+            node.setStatus(m.getStatus());
+            node.setType(m.getType());
+            node.setComponent(m.getComponent());
+            node.setKeepAlive(m.getKeepAlive());
+            node.setExternal(m.getExternal());
+            node.setHidden(m.getHidden());
+            node.setRemark(m.getRemark());
+            map.put(m.getId(), node);
+        }
+        List<MenuTreeNode> roots = new ArrayList<>();
+        for (MenuTreeNode n : map.values()) {
+            if (n.getParentId() == null || n.getParentId().isEmpty()) {
+                roots.add(n);
+            } else {
+                MenuTreeNode parent = map.get(n.getParentId());
+                if (parent != null) {
+                    parent.getChildren().add(n);
+                } else {
+                    roots.add(n);
+                }
+            }
+        }
+        roots.sort(Comparator.comparing(MenuTreeNode::getOrderNum, Comparator.nullsLast(Integer::compareTo)));
+        for (MenuTreeNode n : map.values()) {
+            n.getChildren().sort(Comparator.comparing(MenuTreeNode::getOrderNum, Comparator.nullsLast(Integer::compareTo)));
+        }
+        return roots;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Menu` entity representing `sys_menu`
- create `MenuTreeNode` dto
- implement `MenuRepository` with search query
- add `MenuService` and its implementation for CRUD, status update and tree building
- expose endpoints in `MenuController`

## Testing
- `mvn -f backend/pom.xml -q test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f518091c0832684ff1f23a0ffdecb