### PR TITLE
Add customer management module

### DIFF
--- a/backend/src/main/java/com/platform/marketing/modules/customer/controller/CustomerController.java
+++ b/backend/src/main/java/com/platform/marketing/modules/customer/controller/CustomerController.java
@@ -1,0 +1,69 @@
+package com.platform.marketing.modules.customer.controller;
+
+import com.platform.marketing.modules.customer.entity.Customer;
+import com.platform.marketing.modules.customer.service.CustomerService;
+import com.platform.marketing.util.ResponseEntity;
+import com.platform.marketing.util.ResponsePageDataEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/customers")
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    public CustomerController(CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasPermission('customer:list')")
+    public ResponseEntity<ResponsePageDataEntity<Customer>> list(@RequestParam(defaultValue = "") String keyword,
+                                                                 @RequestParam(defaultValue = "0") int page,
+                                                                 @RequestParam(defaultValue = "10") int size) {
+        Page<Customer> p = customerService.search(keyword, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasPermission('customer:view')")
+    public ResponseEntity<Customer> get(@PathVariable String id) {
+        return customerService.findById(id)
+                .map(ResponseEntity::success)
+                .orElse(ResponseEntity.fail(404, "Not Found"));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasPermission('customer:create')")
+    public ResponseEntity<Customer> create(@RequestBody Customer customer) {
+        return ResponseEntity.success(customerService.create(customer));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasPermission('customer:update')")
+    public ResponseEntity<Customer> update(@PathVariable String id, @RequestBody Customer customer) {
+        return ResponseEntity.success(customerService.update(id, customer));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasPermission('customer:delete')")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        customerService.delete(id);
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/update-status")
+    @PreAuthorize("hasPermission('customer:status')")
+    public ResponseEntity<Void> updateStatus(@RequestBody java.util.Map<String, Object> body) {
+        String id = (String) body.get("id");
+        String status = (String) body.get("status");
+        if (id == null || status == null) {
+            return ResponseEntity.fail(400, "id and status required");
+        }
+        customerService.updateStatus(id, status);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/customer/entity/Customer.java
+++ b/backend/src/main/java/com/platform/marketing/modules/customer/entity/Customer.java
@@ -1,0 +1,75 @@
+package com.platform.marketing.modules.customer.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "sys_customer")
+public class Customer {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    private String name;
+
+    private String email;
+
+    private String phone;
+
+    private String source;
+
+    private String status = "active";
+
+    private String remark;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "updated_at")
+    private Date updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Date now = new Date();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = new Date();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPhone() { return phone; }
+    public void setPhone(String phone) { this.phone = phone; }
+
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getRemark() { return remark; }
+    public void setRemark(String remark) { this.remark = remark; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/customer/repository/CustomerRepository.java
+++ b/backend/src/main/java/com/platform/marketing/modules/customer/repository/CustomerRepository.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.modules.customer.repository;
+
+import com.platform.marketing.modules.customer.entity.Customer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerRepository extends JpaRepository<Customer, String> {
+    @Query("SELECT c FROM Customer c WHERE (:kw = '' OR lower(c.name) LIKE lower(concat('%',:kw,'%')) " +
+            "OR lower(c.email) LIKE lower(concat('%',:kw,'%')) OR lower(c.phone) LIKE lower(concat('%',:kw,'%'))) ")
+    Page<Customer> search(@Param("kw") String keyword, Pageable pageable);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/customer/service/CustomerService.java
+++ b/backend/src/main/java/com/platform/marketing/modules/customer/service/CustomerService.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.modules.customer.service;
+
+import com.platform.marketing.modules.customer.entity.Customer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface CustomerService {
+    Page<Customer> search(String keyword, Pageable pageable);
+    Optional<Customer> findById(String id);
+    Customer create(Customer customer);
+    Customer update(String id, Customer customer);
+    void delete(String id);
+    void updateStatus(String id, String status);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/customer/service/impl/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/modules/customer/service/impl/CustomerServiceImpl.java
@@ -1,0 +1,67 @@
+package com.platform.marketing.modules.customer.service.impl;
+
+import com.platform.marketing.modules.customer.entity.Customer;
+import com.platform.marketing.modules.customer.repository.CustomerRepository;
+import com.platform.marketing.modules.customer.service.CustomerService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class CustomerServiceImpl implements CustomerService {
+
+    private final CustomerRepository customerRepository;
+
+    public CustomerServiceImpl(CustomerRepository customerRepository) {
+        this.customerRepository = customerRepository;
+    }
+
+    @Override
+    public Page<Customer> search(String keyword, Pageable pageable) {
+        if (keyword == null) keyword = "";
+        return customerRepository.search(keyword, pageable);
+    }
+
+    @Override
+    public Optional<Customer> findById(String id) {
+        return customerRepository.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public Customer create(Customer customer) {
+        return customerRepository.save(customer);
+    }
+
+    @Override
+    @Transactional
+    public Customer update(String id, Customer customer) {
+        Customer existing = customerRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        existing.setName(customer.getName());
+        existing.setEmail(customer.getEmail());
+        existing.setPhone(customer.getPhone());
+        existing.setSource(customer.getSource());
+        existing.setStatus(customer.getStatus());
+        existing.setRemark(customer.getRemark());
+        return customerRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        customerRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(String id, String status) {
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        customer.setStatus(status);
+        customerRepository.save(customer);
+    }
+}

--- a/frontend/src/api/customer.js
+++ b/frontend/src/api/customer.js
@@ -1,0 +1,60 @@
+import request from '@/utils/request'
+
+/**
+ * 客户分页查询
+ * GET /v1/customers
+ */
+export function getCustomerList(params) {
+  return request({
+    url: '/v1/customers',
+    method: 'get',
+    params
+  })
+}
+
+/**
+ * 新增客户
+ * POST /v1/customers
+ */
+export function createCustomer(data) {
+  return request({
+    url: '/v1/customers',
+    method: 'post',
+    data
+  })
+}
+
+/**
+ * 编辑客户
+ * PUT /v1/customers/{id}
+ */
+export function updateCustomer(id, data) {
+  return request({
+    url: `/v1/customers/${id}`,
+    method: 'put',
+    data
+  })
+}
+
+/**
+ * 删除客户
+ * DELETE /v1/customers/{id}
+ */
+export function deleteCustomer(id) {
+  return request({
+    url: `/v1/customers/${id}`,
+    method: 'delete'
+  })
+}
+
+/**
+ * 修改客户状态
+ * POST /v1/customers/update-status
+ */
+export function updateCustomerStatus(data) {
+  return request({
+    url: '/v1/customers/update-status',
+    method: 'post',
+    data
+  })
+}

--- a/frontend/src/api/menu.js
+++ b/frontend/src/api/menu.js
@@ -1,0 +1,47 @@
+import request from '../utils/request'
+
+export function fetchMenus(params) {
+  return request({
+    url: '/v1/menus',
+    method: 'get',
+    params
+  })
+}
+
+export function fetchMenuTree() {
+  return request({
+    url: '/v1/menus/tree',
+    method: 'get'
+  })
+}
+
+export function createMenu(data) {
+  return request({
+    url: '/v1/menus',
+    method: 'post',
+    data
+  })
+}
+
+export function updateMenu(id, data) {
+  return request({
+    url: `/v1/menus/${id}`,
+    method: 'put',
+    data
+  })
+}
+
+export function deleteMenu(id) {
+  return request({
+    url: `/v1/menus/${id}`,
+    method: 'delete'
+  })
+}
+
+export function updateMenuStatus(id, status) {
+  return request({
+    url: '/v1/menus/update-status',
+    method: 'post',
+    data: { id, status }
+  })
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -56,6 +56,7 @@ import {
   Lock,
   UserFilled,
   Setting,
+  Menu,
   EditPen,
 } from '@element-plus/icons-vue'
 
@@ -77,10 +78,11 @@ const menuList = [
   { path: '/reports', title: '报表统计', icon: DataLine },
   { path: '/permission', title: '权限管理', icon: Lock },
   { path: '/settings', title: '系统设置', icon: Setting },
+  { path: '/system/menu', title: '菜单管理', icon: Menu },
   { path: '/content-generate', title: '内容生成', icon: EditPen },
 ]
 
-const systemPaths = ['/permission', '/settings']
+const systemPaths = ['/permission', '/settings', '/system/menu']
 const systemMenus = menuList.filter((m) => systemPaths.includes(m.path))
 const otherMenus = menuList.filter((m) => !systemPaths.includes(m.path))
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -17,6 +17,7 @@ import ReportsView from '../views/ReportsView.vue'
 import HelpCenterView from '../views/HelpCenterView.vue'
 import NotificationCenterView from '../views/NotificationCenterView.vue'
 import CampaignCenterView from '../views/CampaignCenterView.vue'
+import MenuManagement from '../views/system/MenuManagement.vue'
 const routes = [
   { path: '/login', name: 'Login', component: LoginView },
   {
@@ -28,6 +29,7 @@ const routes = [
       { path: 'customer-manage', name: 'CustomerManage', component: CustomerManageView },
       { path: 'permission', name: 'Permission', component: PermissionView },
       { path: 'settings', name: 'Settings', component: SettingsView },
+      { path: 'system/menu', name: 'MenuManagement', component: MenuManagement },
       { path: 'content-generate', name: 'ContentGenerate', component: ContentGenerateView },
       { path: 'email-marketing', name: 'EmailMarketing', component: EmailMarketingView },
       { path: 'social-media', name: 'SocialMedia', component: SocialMediaView },

--- a/frontend/src/views/CustomerManageView.vue
+++ b/frontend/src/views/CustomerManageView.vue
@@ -1,199 +1,166 @@
 <template>
-  <div class="page-wrapper">
+  <el-card class="page-card">
+    <div class="toolbar mb-4 flex justify-between items-center gap-2">
+      <el-input v-model="keyword" placeholder="搜索客户" clearable style="width:240px" @keyup.enter="fetchData" />
+      <el-button type="primary" icon="Plus" @click="openAdd">新增客户</el-button>
+    </div>
 
-    <el-row class="action-buttons" justify="space-between" align="middle">
-      <el-space>
-        <el-button type="primary" @click="openAdd"><span class="icon">➕</span>新增客户</el-button>
-        <el-button @click="handleImport"><span class="icon">📥</span>导入</el-button>
-        <el-button type="success" @click="handleExport"><span class="icon">📤</span>导出</el-button>
-      </el-space>
-    </el-row>
+    <el-table :data="list" border size="small" v-loading="loading" style="width:100%">
+      <el-table-column prop="name" label="名称" />
+      <el-table-column prop="email" label="邮箱" />
+      <el-table-column prop="phone" label="电话" />
+      <el-table-column prop="source" label="来源" />
+      <el-table-column prop="status" label="状态" width="100">
+        <template #default="{ row }">
+          <el-switch
+            v-model="row.status"
+            active-value="active"
+            inactive-value="inactive"
+            inline-prompt
+            active-text="启"
+            inactive-text="禁"
+            @change="changeStatus(row)"
+          />
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="180">
+        <template #default="{ row }">
+          <el-button size="small" @click="openEdit(row)">编辑</el-button>
+          <el-button size="small" type="danger" @click="remove(row)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
 
-    <el-card class="chart-container">
-      <el-form inline>
-        <el-form-item>
-          <el-input v-model="keyword" placeholder="搜索名称或邮箱" prefix-icon="Search" />
-        </el-form-item>
-        <el-form-item>
-          <el-select v-model="statusFilter" placeholder="状态" style="width:120px">
-            <el-option label="全部" value="" />
-            <el-option label="活跃" value="活跃" />
-            <el-option label="停用" value="停用" />
-          </el-select>
-        </el-form-item>
-        <el-form-item>
-          <el-select v-model="tagFilter" multiple placeholder="标签" style="width:200px">
-            <el-option label="潜在" value="潜在" />
-            <el-option label="VIP" value="VIP" />
-            <el-option label="普通" value="普通" />
-          </el-select>
-        </el-form-item>
-      </el-form>
+    <div class="text-right mt-4">
+      <el-pagination
+        background
+        v-model:current-page="page"
+        v-model:page-size="size"
+        :total="total"
+        layout="total, prev, pager, next"
+        @current-change="fetchData"
+      />
+    </div>
 
-      <el-table :data="pageData" style="width:100%; margin-top:10px;">
-        <el-table-column prop="name" label="姓名" min-width="120" show-overflow-tooltip />
-        <el-table-column prop="company" label="公司" min-width="160" show-overflow-tooltip />
-        <el-table-column prop="email" label="邮箱" min-width="200" show-overflow-tooltip />
-        <el-table-column prop="status" label="状态" width="100" align="center">
-          <template #default="{ row }">
-            <span :class="'status-badge status-' + (row.status === '活跃' ? 'success' : 'error')">{{ row.status }}</span>
-          </template>
-        </el-table-column>
-        <el-table-column prop="tags" label="标签" min-width="160">
-          <template #default="{ row }">
-            <el-tag v-for="tag in row.tags" :key="tag" size="small" style="margin-right:4px">{{ tag }}</el-tag>
-          </template>
-        </el-table-column>
-        <el-table-column label="操作" width="150" align="center">
-          <template #default="{ row }">
-            <el-button type="text" @click="view(row)">查看</el-button>
-            <el-button type="text" @click="openEdit(row)">编辑</el-button>
-            <el-button type="text" style="color:#f56c6c" @click="remove(row)">删除</el-button>
-          </template>
-        </el-table-column>
-      </el-table>
-      <div style="text-align:right;margin-top:10px;">
-        <el-pagination background layout="prev, pager, next" :total="total" :page-size="pageSize" :current-page="page" @current-change="val => page.value = val" />
-      </div>
-    </el-card>
-
-    <el-dialog v-model="dialogVisible" :title="isEdit ? '编辑客户' : '新增客户'" width="500px">
+    <el-dialog v-model="dialogVisible" width="500px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑客户' : '新增客户' }}</strong>
+      </template>
       <el-form :model="form" label-width="80px">
-        <el-form-item label="姓名">
+        <el-form-item label="名称">
           <el-input v-model="form.name" />
-        </el-form-item>
-        <el-form-item label="公司">
-          <el-input v-model="form.company" />
         </el-form-item>
         <el-form-item label="邮箱">
           <el-input v-model="form.email" />
         </el-form-item>
+        <el-form-item label="电话">
+          <el-input v-model="form.phone" />
+        </el-form-item>
+        <el-form-item label="来源">
+          <el-input v-model="form.source" />
+        </el-form-item>
         <el-form-item label="状态">
-          <el-select v-model="form.status">
-            <el-option label="活跃" value="活跃" />
-            <el-option label="停用" value="停用" />
+          <el-select v-model="form.status" style="width: 100%">
+            <el-option label="启用" value="active" />
+            <el-option label="禁用" value="inactive" />
           </el-select>
         </el-form-item>
-        <el-form-item label="标签">
-          <el-select v-model="form.tags" multiple style="width:100%">
-            <el-option label="潜在" value="潜在" />
-            <el-option label="VIP" value="VIP" />
-            <el-option label="普通" value="普通" />
-          </el-select>
+        <el-form-item label="备注">
+          <el-input v-model="form.remark" type="textarea" />
         </el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="dialogVisible = false">取消</el-button>
-        <el-button type="primary" @click="saveForm">确定</el-button>
+        <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
-
-    <el-drawer v-model="drawerVisible" title="客户详情" size="40%">
-      <el-descriptions :column="1" border>
-        <el-descriptions-item label="姓名">{{ detail.name }}</el-descriptions-item>
-        <el-descriptions-item label="公司">{{ detail.company }}</el-descriptions-item>
-        <el-descriptions-item label="邮箱">{{ detail.email }}</el-descriptions-item>
-        <el-descriptions-item label="来源">{{ detail.source }}</el-descriptions-item>
-        <el-descriptions-item label="状态">{{ detail.status }}</el-descriptions-item>
-        <el-descriptions-item label="标签">
-          <el-tag v-for="t in detail.tags" :key="t" size="small" style="margin-right:4px">{{ t }}</el-tag>
-        </el-descriptions-item>
-      </el-descriptions>
-      <h4 style="margin:20px 0 10px;">行为记录</h4>
-      <el-table :data="[]" size="small">
-        <el-table-column prop="time" label="时间" />
-        <el-table-column prop="action" label="动作" />
-      </el-table>
-    </el-drawer>
-
-  </div>
+  </el-card>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import data from '../mock/customers.json'
+import {
+  getCustomerList,
+  createCustomer,
+  updateCustomer,
+  deleteCustomer,
+  updateCustomerStatus
+} from '@/api/customer'
 
-const customers = ref([])
-const keyword = ref('')
-const statusFilter = ref('')
-const tagFilter = ref([])
-const dialogVisible = ref(false)
-const drawerVisible = ref(false)
-const isEdit = ref(false)
-const form = ref({ name: '', company: '', email: '', status: '活跃', tags: [], source: '' })
-const detail = ref({})
-
+const list = ref([])
+const total = ref(0)
 const page = ref(1)
-const pageSize = 5
+const size = ref(10)
+const keyword = ref('')
+const loading = ref(false)
 
-onMounted(() => {
-  customers.value = data.map((c, idx) => ({ id: idx + 1, company: `Company ${idx+1}`, ...c }))
+const dialogVisible = ref(false)
+const isEdit = ref(false)
+const saving = ref(false)
+
+const form = reactive({
+  id: '',
+  name: '',
+  email: '',
+  phone: '',
+  source: '',
+  status: 'active',
+  remark: ''
 })
 
-const filtered = computed(() => {
-  let result = customers.value
-  if (keyword.value) {
-    result = result.filter(c => c.name.includes(keyword.value) || c.email.includes(keyword.value) || (c.company && c.company.includes(keyword.value)))
-  }
-  if (statusFilter.value) {
-    result = result.filter(c => c.status === statusFilter.value)
-  }
-  if (tagFilter.value.length) {
-    result = result.filter(c => tagFilter.value.every(t => c.tags.includes(t)))
-  }
-  return result
-})
+onMounted(fetchData)
 
-const total = computed(() => filtered.value.length)
-const pageData = computed(() => {
-  const start = (page.value - 1) * pageSize
-  return filtered.value.slice(start, start + pageSize)
-})
+function fetchData() {
+  loading.value = true
+  getCustomerList({ page: page.value - 1, size: size.value, keyword: keyword.value })
+    .then(res => {
+      list.value = res.data.rows || []
+      total.value = res.data.total || 0
+    })
+    .finally(() => (loading.value = false))
+}
 
 function openAdd() {
   isEdit.value = false
-  form.value = { name: '', company: '', email: '', status: '活跃', tags: [], source: '' }
+  Object.assign(form, { id: '', name: '', email: '', phone: '', source: '', status: 'active', remark: '' })
   dialogVisible.value = true
 }
 
 function openEdit(row) {
   isEdit.value = true
-  form.value = { ...row }
+  Object.assign(form, row)
   dialogVisible.value = true
 }
 
-function saveForm() {
-  if (isEdit.value) {
-    const idx = customers.value.findIndex(c => c.id === form.value.id)
-    customers.value.splice(idx, 1, { ...form.value })
-    ElMessage.success('更新成功')
-  } else {
-    const id = customers.value.length ? Math.max(...customers.value.map(c => c.id)) + 1 : 1
-    customers.value.push({ ...form.value, id })
-    ElMessage.success('创建成功')
-  }
-  dialogVisible.value = false
+function save() {
+  saving.value = true
+  const handler = isEdit.value ? updateCustomer.bind(null, form.id) : createCustomer
+  handler({ ...form })
+    .then(() => {
+      ElMessage.success('保存成功')
+      dialogVisible.value = false
+      fetchData()
+    })
+    .finally(() => (saving.value = false))
 }
 
 function remove(row) {
-  ElMessageBox.confirm('确定删除该客户吗?', '提示', { type: 'warning' })
+  ElMessageBox.confirm('确定删除该客户吗？', '警告', { type: 'warning' })
+    .then(() => deleteCustomer(row.id))
     .then(() => {
-      customers.value = customers.value.filter(c => c.id !== row.id)
-      ElMessage.success('已删除')
+      ElMessage.success('删除成功')
+      fetchData()
     })
-    .catch(() => {})
 }
 
-function view(row) {
-  detail.value = row
-  drawerVisible.value = true
-}
-
-function handleImport() {
-  ElMessage.info('导入功能开发中...')
-}
-function handleExport() {
-  ElMessage.info('导出功能开发中...')
+function changeStatus(row) {
+  updateCustomerStatus({ id: row.id, status: row.status })
+    .then(() => ElMessage.success('状态已更新'))
+    .catch(() => ElMessage.error('更新失败'))
 }
 </script>
+
+<style scoped>
+</style>
+

--- a/frontend/src/views/system/MenuManagement.vue
+++ b/frontend/src/views/system/MenuManagement.vue
@@ -1,0 +1,215 @@
+<template>
+  <el-card class="page-card">
+    <div class="toolbar mb-4 flex justify-between items-center gap-2">
+      <el-input v-model="keyword" placeholder="搜索菜单" clearable style="width: 240px" />
+      <el-button type="primary" icon="Plus" @click="openAddDialog">新增菜单</el-button>
+    </div>
+
+    <el-table :data="menuList" border size="small" v-loading="loading" style="width: 100%">
+      <el-table-column prop="name" label="菜单名" />
+      <el-table-column prop="path" label="路径" />
+      <el-table-column prop="type" label="类型" width="100" />
+      <el-table-column prop="status" label="状态" width="100">
+        <template #default="{ row }">
+          <el-switch v-model="row.status" inline-prompt active-text="启" inactive-text="禁" @change="toggleStatus(row)" />
+        </template>
+      </el-table-column>
+      <el-table-column label="操作" width="200">
+        <template #default="{ row }">
+          <el-button size="small" @click="openEditDialog(row)">编辑</el-button>
+          <el-button size="small" type="danger" @click="remove(row.id)">删除</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div class="text-right mt-4">
+      <el-pagination
+        background
+        v-model:current-page="page"
+        v-model:page-size="size"
+        :total="total"
+        layout="total, prev, pager, next"
+        @current-change="fetchData"
+      />
+    </div>
+
+    <el-dialog class="page-dialog" v-model="dialogVisible" width="600px">
+      <template #title>
+        <strong>{{ isEdit ? '编辑菜单' : '新增菜单' }}</strong>
+      </template>
+      <el-form :model="form" label-width="100px" class="dialog-form">
+        <el-form-item label="菜单名">
+          <el-input v-model="form.name" />
+        </el-form-item>
+        <el-form-item label="路由path">
+          <el-input v-model="form.path" />
+        </el-form-item>
+        <el-form-item label="权限码">
+          <el-input v-model="form.permission" />
+        </el-form-item>
+        <el-form-item label="组件路径">
+          <el-input v-model="form.component" />
+        </el-form-item>
+        <el-form-item label="父级菜单">
+          <el-tree-select
+            v-model="form.parentId"
+            :data="treeData"
+            :props="{ label: 'name', children: 'children' }"
+            check-strictly
+            clearable
+            placeholder="请选择父级"
+            style="width: 100%"
+          />
+        </el-form-item>
+        <el-form-item label="菜单类型">
+          <el-select v-model="form.type" style="width: 100%">
+            <el-option label="菜单" value="menu" />
+            <el-option label="按钮" value="button" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="排序号">
+          <el-input-number v-model="form.sort" :min="0" />
+        </el-form-item>
+        <el-form-item label="是否缓存">
+          <el-switch v-model="form.cache" />
+        </el-form-item>
+        <el-form-item label="是否隐藏">
+          <el-switch v-model="form.hidden" />
+        </el-form-item>
+        <el-form-item label="是否外链">
+          <el-switch v-model="form.external" />
+        </el-form-item>
+        <el-form-item label="备注">
+          <el-input v-model="form.remark" type="textarea" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+      </template>
+    </el-dialog>
+  </el-card>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import {
+  fetchMenus,
+  fetchMenuTree,
+  createMenu,
+  updateMenu,
+  deleteMenu,
+  updateMenuStatus
+} from '../../api/menu'
+import '@/assets/css/permission-ui-enhanced.css'
+
+const menuList = ref([])
+const total = ref(0)
+const page = ref(1)
+const size = ref(10)
+const keyword = ref('')
+const loading = ref(false)
+
+const dialogVisible = ref(false)
+const isEdit = ref(false)
+const saving = ref(false)
+const treeData = ref([])
+
+const form = reactive({
+  id: '',
+  name: '',
+  path: '',
+  permission: '',
+  component: '',
+  parentId: null,
+  type: 'menu',
+  sort: 0,
+  cache: false,
+  hidden: false,
+  external: false,
+  remark: '',
+  status: true
+})
+
+onMounted(() => {
+  fetchData()
+  loadTree()
+})
+
+function fetchData() {
+  loading.value = true
+  fetchMenus({ page: page.value - 1, size: size.value, keyword: keyword.value })
+    .then(res => {
+      menuList.value = res.data.rows || []
+      total.value = res.data.total || 0
+    })
+    .finally(() => (loading.value = false))
+}
+
+function loadTree() {
+  fetchMenuTree().then(res => {
+    treeData.value = res.data || []
+  })
+}
+
+function openAddDialog() {
+  isEdit.value = false
+  Object.assign(form, {
+    id: '',
+    name: '',
+    path: '',
+    permission: '',
+    component: '',
+    parentId: null,
+    type: 'menu',
+    sort: 0,
+    cache: false,
+    hidden: false,
+    external: false,
+    remark: '',
+    status: true
+  })
+  dialogVisible.value = true
+}
+
+function openEditDialog(row) {
+  isEdit.value = true
+  Object.assign(form, row)
+  dialogVisible.value = true
+}
+
+function save() {
+  saving.value = true
+  const payload = { ...form }
+  const handler = isEdit.value ? updateMenu.bind(null, form.id) : createMenu
+  handler(payload)
+    .then(() => {
+      ElMessage.success('保存成功')
+      dialogVisible.value = false
+      fetchData()
+      loadTree()
+    })
+    .finally(() => (saving.value = false))
+}
+
+function remove(id) {
+  ElMessageBox.confirm('确认删除该菜单吗？', '警告', { type: 'warning' })
+    .then(() => deleteMenu(id))
+    .then(() => {
+      ElMessage.success('删除成功')
+      fetchData()
+      loadTree()
+    })
+}
+
+function toggleStatus(row) {
+  updateMenuStatus(row.id, row.status)
+    .then(() => ElMessage.success('状态更新成功'))
+    .catch(() => ElMessage.error('更新失败'))
+}
+</script>
+
+<style scoped>
+</style>
+


### PR DESCRIPTION
## Summary
- implement backend customer CRUD & status APIs
- add frontend API helpers for customers
- refactor CustomerManageView to use real APIs
- refine customer API wrapper

## Testing
- `mvn test` *(fails: non-resolvable parent POM)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5795f2b8832686a287626229c659