### PR TITLE
Add customer detail view and permission checks

### DIFF
--- a/frontend/src/api/customer.js
+++ b/frontend/src/api/customer.js
@@ -37,6 +37,17 @@ export function updateCustomer(id, data) {
 }
 
 /**
+ * 查询客户详情
+ * GET /v1/customers/{id}
+ */
+export function getCustomer(id) {
+  return request({
+    url: `/v1/customers/${id}`,
+    method: 'get'
+  })
+}
+
+/**
  * 删除客户
  * DELETE /v1/customers/{id}
  */

--- a/frontend/src/components/customer/CustomerDetailDialog.vue
+++ b/frontend/src/components/customer/CustomerDetailDialog.vue
@@ -1,0 +1,40 @@
+<template>
+  <el-dialog v-model="visible" title="客户详情" width="400px">
+    <el-descriptions :column="1" border>
+      <el-descriptions-item label="名称">{{ detail.name }}</el-descriptions-item>
+      <el-descriptions-item label="邮箱">{{ detail.email }}</el-descriptions-item>
+      <el-descriptions-item label="电话">{{ detail.phone }}</el-descriptions-item>
+      <el-descriptions-item label="来源">{{ detail.source }}</el-descriptions-item>
+      <el-descriptions-item label="状态">{{ detail.status }}</el-descriptions-item>
+      <el-descriptions-item label="备注">{{ detail.remark }}</el-descriptions-item>
+    </el-descriptions>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, reactive } from 'vue'
+import { getCustomer } from '@/api/customer'
+
+const visible = ref(false)
+const detail = reactive({
+  name: '',
+  email: '',
+  phone: '',
+  source: '',
+  status: '',
+  remark: ''
+})
+
+function open(id) {
+  if (!id) return
+  getCustomer(id).then(res => {
+    Object.assign(detail, res.data || {})
+    visible.value = true
+  })
+}
+
+defineExpose({ open })
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/views/CustomerManageView.vue
+++ b/frontend/src/views/CustomerManageView.vue
@@ -23,10 +23,21 @@
           />
         </template>
       </el-table-column>
-      <el-table-column label="操作" width="180">
+      <el-table-column label="操作" width="220">
         <template #default="{ row }">
+          <el-button
+            v-if="hasPermission('customer:view')"
+            size="small"
+            type="primary"
+            @click="openDetail(row)"
+          >查看</el-button>
           <el-button size="small" @click="openEdit(row)">编辑</el-button>
-          <el-button size="small" type="danger" @click="remove(row)">删除</el-button>
+          <el-button
+            v-if="hasPermission('customer:delete')"
+            size="small"
+            type="danger"
+            @click="remove(row)"
+          >删除</el-button>
         </template>
       </el-table-column>
     </el-table>
@@ -74,12 +85,15 @@
         <el-button type="primary" :loading="saving" @click="save">保存</el-button>
       </template>
     </el-dialog>
+    <CustomerDetailDialog ref="detailDialog" />
   </el-card>
 </template>
 
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { hasPermission } from '@/composables/permission'
+import CustomerDetailDialog from '../components/customer/CustomerDetailDialog.vue'
 import {
   getCustomerList,
   createCustomer,
@@ -98,6 +112,7 @@ const loading = ref(false)
 const dialogVisible = ref(false)
 const isEdit = ref(false)
 const saving = ref(false)
+const detailDialog = ref()
 
 const form = reactive({
   id: '',
@@ -131,6 +146,10 @@ function openEdit(row) {
   isEdit.value = true
   Object.assign(form, row)
   dialogVisible.value = true
+}
+
+function openDetail(row) {
+  detailDialog.value.open(row.id)
 }
 
 function save() {


### PR DESCRIPTION
## Summary
- allow viewing individual customer details
- control customer management actions with permissions
- support fetching single customer info via API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688044b5dc5c832692d621565628f3a6