### PR TITLE
Add marketing campaign module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ This repository contains a simple marketing platform demo with a frontend built 
 
 The permission management module is implemented in `/frontend/src/views/PermissionView.vue` and corresponding backend code under `/backend`.
 
+The project now also includes a **Marketing Campaign** module exposing REST APIs under `/api/marketing-campaign`.
+
 See `frontend/README.md` for instructions on running the client and `backend/pom.xml` for backend dependencies.

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/controller/MarketingCampaignController.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/controller/MarketingCampaignController.java
@@ -1,0 +1,71 @@
+package com.platform.marketing.modules.campaign.controller;
+
+import com.platform.marketing.modules.campaign.entity.MarketingCampaign;
+import com.platform.marketing.modules.campaign.service.MarketingCampaignService;
+import com.platform.marketing.util.ResponseEntity;
+import com.platform.marketing.util.ResponsePageDataEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/marketing-campaign")
+public class MarketingCampaignController {
+
+    private final MarketingCampaignService marketingCampaignService;
+
+    public MarketingCampaignController(MarketingCampaignService marketingCampaignService) {
+        this.marketingCampaignService = marketingCampaignService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasPermission('campaign:list')")
+    public ResponseEntity<ResponsePageDataEntity<MarketingCampaign>> list(@RequestParam(defaultValue = "") String status,
+                                                                         @RequestParam(defaultValue = "") String channel,
+                                                                         @RequestParam(defaultValue = "") String keyword,
+                                                                         @RequestParam(defaultValue = "0") int page,
+                                                                         @RequestParam(defaultValue = "10") int size) {
+        Page<MarketingCampaign> p = marketingCampaignService.search(status, channel, keyword, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasPermission('campaign:detail')")
+    public ResponseEntity<MarketingCampaign> get(@PathVariable String id) {
+        return marketingCampaignService.findById(id)
+                .map(ResponseEntity::success)
+                .orElse(ResponseEntity.fail(404, "Not Found"));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasPermission('campaign:create')")
+    public ResponseEntity<MarketingCampaign> create(@RequestBody MarketingCampaign campaign) {
+        return ResponseEntity.success(marketingCampaignService.create(campaign));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasPermission('campaign:update')")
+    public ResponseEntity<MarketingCampaign> update(@PathVariable String id, @RequestBody MarketingCampaign campaign) {
+        return ResponseEntity.success(marketingCampaignService.update(id, campaign));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasPermission('campaign:delete')")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        marketingCampaignService.delete(id);
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/update-status")
+    @PreAuthorize("hasPermission('campaign:status:update')")
+    public ResponseEntity<Void> updateStatus(@RequestBody java.util.Map<String, Object> body) {
+        String id = (String) body.get("id");
+        String status = (String) body.get("status");
+        if (id == null || status == null) {
+            return ResponseEntity.fail(400, "id and status required");
+        }
+        marketingCampaignService.updateStatus(id, status);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/dto/MarketingCampaignDto.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/dto/MarketingCampaignDto.java
@@ -1,0 +1,96 @@
+package com.platform.marketing.modules.campaign.dto;
+
+import java.time.LocalDateTime;
+
+public class MarketingCampaignDto {
+    private String id;
+    private String name;
+    private String status;
+    private String channel;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String description;
+    private String createdBy;
+    private LocalDateTime createdTime;
+    private LocalDateTime updatedTime;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(LocalDateTime createdTime) {
+        this.createdTime = createdTime;
+    }
+
+    public LocalDateTime getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(LocalDateTime updatedTime) {
+        this.updatedTime = updatedTime;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/entity/MarketingCampaign.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/entity/MarketingCampaign.java
@@ -1,0 +1,131 @@
+package com.platform.marketing.modules.campaign.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "marketing_campaign")
+public class MarketingCampaign {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    private String name;
+
+    private String status;
+
+    private String channel;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Lob
+    private String description;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_time")
+    private LocalDateTime createdTime;
+
+    @Column(name = "updated_time")
+    private LocalDateTime updatedTime;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdTime = LocalDateTime.now();
+        this.updatedTime = this.createdTime;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedTime = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+
+    public void setCreatedTime(LocalDateTime createdTime) {
+        this.createdTime = createdTime;
+    }
+
+    public LocalDateTime getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(LocalDateTime updatedTime) {
+        this.updatedTime = updatedTime;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/repository/MarketingCampaignRepository.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/repository/MarketingCampaignRepository.java
@@ -1,0 +1,22 @@
+package com.platform.marketing.modules.campaign.repository;
+
+import com.platform.marketing.modules.campaign.entity.MarketingCampaign;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MarketingCampaignRepository extends JpaRepository<MarketingCampaign, String> {
+    @Query("SELECT c FROM MarketingCampaign c WHERE " +
+           "(:status = '' OR c.status = :status) AND " +
+           "(:channel = '' OR c.channel = :channel) AND " +
+           "(:kw = '' OR lower(c.name) LIKE lower(concat('%',:kw,'%')) OR " +
+           "lower(c.description) LIKE lower(concat('%',:kw,'%')))" )
+    Page<MarketingCampaign> search(@Param("status") String status,
+                                   @Param("channel") String channel,
+                                   @Param("kw") String keyword,
+                                   Pageable pageable);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/service/MarketingCampaignService.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/service/MarketingCampaignService.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.modules.campaign.service;
+
+import com.platform.marketing.modules.campaign.entity.MarketingCampaign;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface MarketingCampaignService {
+    Page<MarketingCampaign> search(String status, String channel, String keyword, Pageable pageable);
+    Optional<MarketingCampaign> findById(String id);
+    MarketingCampaign create(MarketingCampaign campaign);
+    MarketingCampaign update(String id, MarketingCampaign campaign);
+    void delete(String id);
+    void updateStatus(String id, String status);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/campaign/service/impl/MarketingCampaignServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/service/impl/MarketingCampaignServiceImpl.java
@@ -1,0 +1,70 @@
+package com.platform.marketing.modules.campaign.service.impl;
+
+import com.platform.marketing.modules.campaign.entity.MarketingCampaign;
+import com.platform.marketing.modules.campaign.repository.MarketingCampaignRepository;
+import com.platform.marketing.modules.campaign.service.MarketingCampaignService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class MarketingCampaignServiceImpl implements MarketingCampaignService {
+
+    private final MarketingCampaignRepository marketingCampaignRepository;
+
+    public MarketingCampaignServiceImpl(MarketingCampaignRepository marketingCampaignRepository) {
+        this.marketingCampaignRepository = marketingCampaignRepository;
+    }
+
+    @Override
+    public Page<MarketingCampaign> search(String status, String channel, String keyword, Pageable pageable) {
+        if (status == null) status = "";
+        if (channel == null) channel = "";
+        if (keyword == null) keyword = "";
+        return marketingCampaignRepository.search(status, channel, keyword, pageable);
+    }
+
+    @Override
+    public Optional<MarketingCampaign> findById(String id) {
+        return marketingCampaignRepository.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public MarketingCampaign create(MarketingCampaign campaign) {
+        return marketingCampaignRepository.save(campaign);
+    }
+
+    @Override
+    @Transactional
+    public MarketingCampaign update(String id, MarketingCampaign campaign) {
+        MarketingCampaign existing = marketingCampaignRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found"));
+        existing.setName(campaign.getName());
+        existing.setStatus(campaign.getStatus());
+        existing.setChannel(campaign.getChannel());
+        existing.setStartTime(campaign.getStartTime());
+        existing.setEndTime(campaign.getEndTime());
+        existing.setDescription(campaign.getDescription());
+        existing.setCreatedBy(campaign.getCreatedBy());
+        return marketingCampaignRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        marketingCampaignRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(String id, String status) {
+        MarketingCampaign campaign = marketingCampaignRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found"));
+        campaign.setStatus(status);
+        marketingCampaignRepository.save(campaign);
+    }
+}


### PR DESCRIPTION
## Summary
- implement MarketingCampaign entity, repository, service, and controller
- provide basic DTO and REST endpoints under `/api/marketing-campaign`
- update README with new module info

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880530266408326ae9f1ff95d5a8c88