### PR TITLE
Add watchers and pagination update for Marketing Campaign view

### DIFF
--- a/frontend/src/views/marketing/MarketingCampaignView.vue
+++ b/frontend/src/views/marketing/MarketingCampaignView.vue
@@ -48,6 +48,7 @@
         :total="total"
         layout="total, prev, pager, next"
         @current-change="fetchData"
+        @size-change="fetchData"
       />
     </div>
 
@@ -93,7 +94,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted, watch } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import marketingApi from '@/api/marketingCampaign'
 
@@ -120,6 +121,13 @@ const form = reactive({
 })
 
 onMounted(fetchData)
+watch(
+  [() => query.channel, () => query.status],
+  () => {
+    page.value = 1
+    fetchData()
+  }
+)
 
 function fetchData() {
   loading.value = true
@@ -198,7 +206,7 @@ function statusText(s) {
 }
 
 function tagType(s) {
-  const map = { running: 'success', paused: 'warning', ended: 'info' }
+  const map = { draft: 'info', running: 'success', paused: 'warning', ended: 'info' }
   return map[s] || ''
 }
 </script>


### PR DESCRIPTION
## Summary
- refresh campaign list when filters change
- refresh pagination when page size changes
- show draft status with info tag color

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68805bd0480c8326ab9889ff3a0d24f4