### PR TITLE
Add publish/toggle API

### DIFF
--- a/backend/src/main/java/com/platform/marketing/modules/campaign/controller/MarketingCampaignController.java
+++ b/backend/src/main/java/com/platform/marketing/modules/campaign/controller/MarketingCampaignController.java
@@ -81,4 +81,32 @@ public class MarketingCampaignController {
         marketingCampaignService.updateStatus(dto.getId(), dto.getStatus());
         return ResponseEntity.success(null);
     }
+
+    @PostMapping("/publish")
+    @PreAuthorize("hasPermission('campaign:publish')")
+    public ResponseEntity<Void> publish(@RequestBody java.util.Map<String, String> body) {
+        String id = body.get("id");
+        if (id == null) {
+            return ResponseEntity.fail(400, "id required");
+        }
+        marketingCampaignService.updateStatus(id, "running");
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/toggle")
+    @PreAuthorize("hasPermission('campaign:toggle')")
+    public ResponseEntity<Void> toggle(@RequestBody java.util.Map<String, String> body) {
+        String id = body.get("id");
+        if (id == null) {
+            return ResponseEntity.fail(400, "id required");
+        }
+        return marketingCampaignService.findById(id)
+                .map(campaign -> {
+                    String current = campaign.getStatus();
+                    String status = "paused".equals(current) ? "running" : "paused";
+                    marketingCampaignService.updateStatus(id, status);
+                    return ResponseEntity.success(null);
+                })
+                .orElse(ResponseEntity.fail(404, "Not Found"));
+    }
 }


### PR DESCRIPTION
## Summary
- add POST `/publish` endpoint to run a campaign
- add POST `/toggle` endpoint to switch a campaign between paused and running

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688096c652ac83269a9f42ece25c3860