### PR TITLE
Add email campaign module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ The permission management module is implemented in `/frontend/src/views/system/P
 
 The project now also includes a **Marketing Campaign** module exposing REST APIs under `/api/marketing-campaign`. Status updates use a `PATCH /status` endpoint.
 
+An **Email Campaign** module is available under `/api/email-campaign` for managing email templates and send records.
+
 
 See `frontend/README.md` for instructions on running the client and `backend/pom.xml` for backend dependencies.

--- a/backend/src/main/java/com/platform/marketing/modules/email/controller/EmailCampaignController.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/controller/EmailCampaignController.java
@@ -1,0 +1,86 @@
+package com.platform.marketing.modules.email.controller;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignTemplate;
+import com.platform.marketing.modules.email.entity.EmailCampaignRecord;
+import com.platform.marketing.modules.email.service.EmailCampaignTemplateService;
+import com.platform.marketing.modules.email.service.EmailCampaignRecordService;
+import com.platform.marketing.util.ResponseEntity;
+import com.platform.marketing.util.ResponsePageDataEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/email-campaign")
+public class EmailCampaignController {
+
+    private final EmailCampaignTemplateService templateService;
+    private final EmailCampaignRecordService recordService;
+
+    public EmailCampaignController(EmailCampaignTemplateService templateService,
+                                   EmailCampaignRecordService recordService) {
+        this.templateService = templateService;
+        this.recordService = recordService;
+    }
+
+    // Template endpoints
+    @GetMapping("/templates")
+    @PreAuthorize("hasPermission('email-campaign:template:list')")
+    public ResponseEntity<ResponsePageDataEntity<EmailCampaignTemplate>> listTemplates(
+            @RequestParam(defaultValue = "") String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<EmailCampaignTemplate> p = templateService.search(keyword, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @PostMapping("/templates")
+    @PreAuthorize("hasPermission('email-campaign:template:create')")
+    public ResponseEntity<EmailCampaignTemplate> createTemplate(@RequestBody EmailCampaignTemplate template) {
+        return ResponseEntity.success(templateService.create(template));
+    }
+
+    @PutMapping("/templates/{id}")
+    @PreAuthorize("hasPermission('email-campaign:template:update')")
+    public ResponseEntity<EmailCampaignTemplate> updateTemplate(@PathVariable String id,
+                                                                @RequestBody EmailCampaignTemplate template) {
+        return ResponseEntity.success(templateService.update(id, template));
+    }
+
+    @DeleteMapping("/templates/{id}")
+    @PreAuthorize("hasPermission('email-campaign:template:delete')")
+    public ResponseEntity<Void> deleteTemplate(@PathVariable String id) {
+        templateService.delete(id);
+        return ResponseEntity.success(null);
+    }
+
+    // Records endpoints
+    @GetMapping("/records")
+    @PreAuthorize("hasPermission('email-campaign:record:list')")
+    public ResponseEntity<ResponsePageDataEntity<EmailCampaignRecord>> listRecords(
+            @RequestParam(defaultValue = "") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<EmailCampaignRecord> p = recordService.search(status, PageRequest.of(page, size));
+        return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
+    }
+
+    @PostMapping("/records")
+    @PreAuthorize("hasPermission('email-campaign:record:create')")
+    public ResponseEntity<EmailCampaignRecord> createRecord(@RequestBody EmailCampaignRecord record) {
+        return ResponseEntity.success(recordService.create(record));
+    }
+
+    @PostMapping("/test-send")
+    @PreAuthorize("hasPermission('email-campaign:test-send')")
+    public ResponseEntity<Void> testSend(@RequestBody Map<String, String> body) {
+        // In real implementation we'd send an email here
+        if (!body.containsKey("email")) {
+            return ResponseEntity.fail(400, "email required");
+        }
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/entity/EmailCampaignRecord.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/entity/EmailCampaignRecord.java
@@ -1,0 +1,64 @@
+package com.platform.marketing.modules.email.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_campaign_record")
+public class EmailCampaignRecord {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(name = "template_id")
+    private String templateId;
+
+    private String groups;
+
+    @Lob
+    private String content;
+
+    private String status = "pending";
+
+    @Column(name = "total_count")
+    private Integer totalCount = 0;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getTemplateId() { return templateId; }
+    public void setTemplateId(String templateId) { this.templateId = templateId; }
+
+    public String getGroups() { return groups; }
+    public void setGroups(String groups) { this.groups = groups; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public Integer getTotalCount() { return totalCount; }
+    public void setTotalCount(Integer totalCount) { this.totalCount = totalCount; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/entity/EmailCampaignTemplate.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/entity/EmailCampaignTemplate.java
@@ -1,0 +1,47 @@
+package com.platform.marketing.modules.email.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_campaign_template")
+public class EmailCampaignTemplate {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Lob
+    private String content;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/repository/EmailCampaignRecordRepository.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/repository/EmailCampaignRecordRepository.java
@@ -1,0 +1,15 @@
+package com.platform.marketing.modules.email.repository;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailCampaignRecordRepository extends JpaRepository<EmailCampaignRecord, String> {
+    @Query("SELECT r FROM EmailCampaignRecord r WHERE (:status = '' OR r.status = :status)")
+    Page<EmailCampaignRecord> search(@Param("status") String status, Pageable pageable);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/repository/EmailCampaignTemplateRepository.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/repository/EmailCampaignTemplateRepository.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.modules.email.repository;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailCampaignTemplateRepository extends JpaRepository<EmailCampaignTemplate, String> {
+    @Query("SELECT t FROM EmailCampaignTemplate t WHERE (:kw = '' OR lower(t.name) LIKE lower(concat('%',:kw,'%')) " +
+            "OR lower(t.description) LIKE lower(concat('%',:kw,'%')))")
+    Page<EmailCampaignTemplate> search(@Param("kw") String keyword, Pageable pageable);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/EmailCampaignRecordService.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/EmailCampaignRecordService.java
@@ -1,0 +1,10 @@
+package com.platform.marketing.modules.email.service;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface EmailCampaignRecordService {
+    Page<EmailCampaignRecord> search(String status, Pageable pageable);
+    EmailCampaignRecord create(EmailCampaignRecord record);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/EmailCampaignTemplateService.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/EmailCampaignTemplateService.java
@@ -1,0 +1,15 @@
+package com.platform.marketing.modules.email.service;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface EmailCampaignTemplateService {
+    Page<EmailCampaignTemplate> search(String keyword, Pageable pageable);
+    Optional<EmailCampaignTemplate> findById(String id);
+    EmailCampaignTemplate create(EmailCampaignTemplate template);
+    EmailCampaignTemplate update(String id, EmailCampaignTemplate template);
+    void delete(String id);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailCampaignRecordServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailCampaignRecordServiceImpl.java
@@ -1,0 +1,31 @@
+package com.platform.marketing.modules.email.service.impl;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignRecord;
+import com.platform.marketing.modules.email.repository.EmailCampaignRecordRepository;
+import com.platform.marketing.modules.email.service.EmailCampaignRecordService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EmailCampaignRecordServiceImpl implements EmailCampaignRecordService {
+
+    private final EmailCampaignRecordRepository recordRepository;
+
+    public EmailCampaignRecordServiceImpl(EmailCampaignRecordRepository recordRepository) {
+        this.recordRepository = recordRepository;
+    }
+
+    @Override
+    public Page<EmailCampaignRecord> search(String status, Pageable pageable) {
+        if (status == null) status = "";
+        return recordRepository.search(status, pageable);
+    }
+
+    @Override
+    @Transactional
+    public EmailCampaignRecord create(EmailCampaignRecord record) {
+        return recordRepository.save(record);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailCampaignTemplateServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailCampaignTemplateServiceImpl.java
@@ -1,0 +1,55 @@
+package com.platform.marketing.modules.email.service.impl;
+
+import com.platform.marketing.modules.email.entity.EmailCampaignTemplate;
+import com.platform.marketing.modules.email.repository.EmailCampaignTemplateRepository;
+import com.platform.marketing.modules.email.service.EmailCampaignTemplateService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class EmailCampaignTemplateServiceImpl implements EmailCampaignTemplateService {
+
+    private final EmailCampaignTemplateRepository templateRepository;
+
+    public EmailCampaignTemplateServiceImpl(EmailCampaignTemplateRepository templateRepository) {
+        this.templateRepository = templateRepository;
+    }
+
+    @Override
+    public Page<EmailCampaignTemplate> search(String keyword, Pageable pageable) {
+        if (keyword == null) keyword = "";
+        return templateRepository.search(keyword, pageable);
+    }
+
+    @Override
+    public Optional<EmailCampaignTemplate> findById(String id) {
+        return templateRepository.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public EmailCampaignTemplate create(EmailCampaignTemplate template) {
+        return templateRepository.save(template);
+    }
+
+    @Override
+    @Transactional
+    public EmailCampaignTemplate update(String id, EmailCampaignTemplate template) {
+        EmailCampaignTemplate existing = templateRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Template not found"));
+        existing.setName(template.getName());
+        existing.setDescription(template.getDescription());
+        existing.setContent(template.getContent());
+        return templateRepository.save(existing);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        templateRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add email campaign backend with templates and records APIs
- document email campaign module in README

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881976d1a048326a1507d9d6223729d