### PR TITLE
Add dashboard module

### DIFF
--- a/backend/src/main/java/com/platform/marketing/dashboard/controller/DashboardController.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/controller/DashboardController.java
@@ -1,0 +1,54 @@
+package com.platform.marketing.dashboard.controller;
+
+import com.platform.marketing.dashboard.dto.DashboardMetricsDto;
+import com.platform.marketing.dashboard.dto.RecentTaskDto;
+import com.platform.marketing.dashboard.dto.TrendPoint;
+import com.platform.marketing.dashboard.service.DashboardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    public DashboardController(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @GetMapping("/stats")
+    @PreAuthorize("hasPermission('dashboard:stats')")
+    public ResponseEntity<DashboardMetricsDto> getStats() {
+        return ResponseEntity.ok(dashboardService.getDashboardStats());
+    }
+
+    @GetMapping("/trend/send")
+    @PreAuthorize("hasPermission('dashboard:trend')")
+    public ResponseEntity<List<TrendPoint>> getSendTrend() {
+        return ResponseEntity.ok(dashboardService.getSendTrend());
+    }
+
+    @GetMapping("/trend/customers")
+    @PreAuthorize("hasPermission('dashboard:trend')")
+    public ResponseEntity<List<TrendPoint>> getCustomerTrend() {
+        return ResponseEntity.ok(dashboardService.getCustomerTrend());
+    }
+
+    @GetMapping("/tasks")
+    @PreAuthorize("hasPermission('dashboard:tasks')")
+    public ResponseEntity<List<RecentTaskDto>> getTasks() {
+        return ResponseEntity.ok(dashboardService.getRecentTasks());
+    }
+
+    @GetMapping("/tasks/{id}")
+    @PreAuthorize("hasPermission('dashboard:task-view')")
+    public ResponseEntity<RecentTaskDto> getTask(@PathVariable String id) {
+        return dashboardService.getTask(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/dto/DashboardMetricsDto.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/dto/DashboardMetricsDto.java
@@ -1,0 +1,13 @@
+package com.platform.marketing.dashboard.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class DashboardMetricsDto {
+    private int totalCustomers;
+    private int emailsSentToday;
+    private BigDecimal openRate;
+    private int runningTasks;
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/dto/RecentTaskDto.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/dto/RecentTaskDto.java
@@ -1,0 +1,14 @@
+package com.platform.marketing.dashboard.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class RecentTaskDto {
+    private String id;
+    private String name;
+    private String status;
+    private int progress;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/dto/TrendPoint.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/dto/TrendPoint.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.dashboard.dto;
+
+import lombok.Data;
+
+@Data
+public class TrendPoint {
+    private String date;
+    private int value;
+
+    public TrendPoint() {}
+
+    public TrendPoint(String date, int value) {
+        this.date = date;
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/entity/DashboardMetrics.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/entity/DashboardMetrics.java
@@ -1,0 +1,85 @@
+package com.platform.marketing.dashboard.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dashboard_metrics")
+public class DashboardMetrics {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    @Column(name = "total_customers")
+    private int totalCustomers;
+
+    @Column(name = "emails_sent_today")
+    private int emailsSentToday;
+
+    @Column(name = "open_rate")
+    private BigDecimal openRate;
+
+    @Column(name = "running_tasks")
+    private int runningTasks;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getTotalCustomers() {
+        return totalCustomers;
+    }
+
+    public void setTotalCustomers(int totalCustomers) {
+        this.totalCustomers = totalCustomers;
+    }
+
+    public int getEmailsSentToday() {
+        return emailsSentToday;
+    }
+
+    public void setEmailsSentToday(int emailsSentToday) {
+        this.emailsSentToday = emailsSentToday;
+    }
+
+    public BigDecimal getOpenRate() {
+        return openRate;
+    }
+
+    public void setOpenRate(BigDecimal openRate) {
+        this.openRate = openRate;
+    }
+
+    public int getRunningTasks() {
+        return runningTasks;
+    }
+
+    public void setRunningTasks(int runningTasks) {
+        this.runningTasks = runningTasks;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/entity/RecentTask.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/entity/RecentTask.java
@@ -1,0 +1,70 @@
+package com.platform.marketing.dashboard.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recent_task")
+public class RecentTask {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    private String name;
+
+    private String status;
+
+    private int progress;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public void setProgress(int progress) {
+        this.progress = progress;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/repository/DashboardMetricsRepository.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/repository/DashboardMetricsRepository.java
@@ -1,0 +1,13 @@
+package com.platform.marketing.dashboard.repository;
+
+import com.platform.marketing.dashboard.entity.DashboardMetrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DashboardMetricsRepository extends JpaRepository<DashboardMetrics, String> {
+    DashboardMetrics findTopByOrderByCreatedAtDesc();
+    List<DashboardMetrics> findTop30ByOrderByCreatedAtAsc();
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/repository/RecentTaskRepository.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/repository/RecentTaskRepository.java
@@ -1,0 +1,12 @@
+package com.platform.marketing.dashboard.repository;
+
+import com.platform.marketing.dashboard.entity.RecentTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecentTaskRepository extends JpaRepository<RecentTask, String> {
+    List<RecentTask> findTop10ByOrderByCreatedAtDesc();
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/service/DashboardService.java
@@ -1,0 +1,20 @@
+package com.platform.marketing.dashboard.service;
+
+import com.platform.marketing.dashboard.dto.DashboardMetricsDto;
+import com.platform.marketing.dashboard.dto.RecentTaskDto;
+import com.platform.marketing.dashboard.dto.TrendPoint;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DashboardService {
+    DashboardMetricsDto getDashboardStats();
+
+    List<TrendPoint> getSendTrend();
+
+    List<TrendPoint> getCustomerTrend();
+
+    List<RecentTaskDto> getRecentTasks();
+
+    Optional<RecentTaskDto> getTask(String id);
+}

--- a/backend/src/main/java/com/platform/marketing/dashboard/service/impl/DashboardServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/dashboard/service/impl/DashboardServiceImpl.java
@@ -1,0 +1,88 @@
+package com.platform.marketing.dashboard.service.impl;
+
+import com.platform.marketing.dashboard.dto.DashboardMetricsDto;
+import com.platform.marketing.dashboard.dto.RecentTaskDto;
+import com.platform.marketing.dashboard.dto.TrendPoint;
+import com.platform.marketing.dashboard.entity.DashboardMetrics;
+import com.platform.marketing.dashboard.entity.RecentTask;
+import com.platform.marketing.dashboard.repository.DashboardMetricsRepository;
+import com.platform.marketing.dashboard.repository.RecentTaskRepository;
+import com.platform.marketing.dashboard.service.DashboardService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class DashboardServiceImpl implements DashboardService {
+
+    private final DashboardMetricsRepository metricsRepository;
+    private final RecentTaskRepository recentTaskRepository;
+
+    public DashboardServiceImpl(DashboardMetricsRepository metricsRepository, RecentTaskRepository recentTaskRepository) {
+        this.metricsRepository = metricsRepository;
+        this.recentTaskRepository = recentTaskRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DashboardMetricsDto getDashboardStats() {
+        DashboardMetrics metrics = metricsRepository.findTopByOrderByCreatedAtDesc();
+        if (metrics == null) {
+            return new DashboardMetricsDto();
+        }
+        DashboardMetricsDto dto = new DashboardMetricsDto();
+        dto.setTotalCustomers(metrics.getTotalCustomers());
+        dto.setEmailsSentToday(metrics.getEmailsSentToday());
+        dto.setOpenRate(metrics.getOpenRate());
+        dto.setRunningTasks(metrics.getRunningTasks());
+        return dto;
+    }
+
+    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TrendPoint> getSendTrend() {
+        List<DashboardMetrics> metrics = metricsRepository.findTop30ByOrderByCreatedAtAsc();
+        return metrics.stream()
+                .map(m -> new TrendPoint(m.getCreatedAt().format(DF), m.getEmailsSentToday()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TrendPoint> getCustomerTrend() {
+        List<DashboardMetrics> metrics = metricsRepository.findTop30ByOrderByCreatedAtAsc();
+        return metrics.stream()
+                .map(m -> new TrendPoint(m.getCreatedAt().format(DF), m.getTotalCustomers()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RecentTaskDto> getRecentTasks() {
+        return recentTaskRepository.findTop10ByOrderByCreatedAtDesc().stream()
+                .map(this::convert)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<RecentTaskDto> getTask(String id) {
+        return recentTaskRepository.findById(id).map(this::convert);
+    }
+
+    private RecentTaskDto convert(RecentTask task) {
+        RecentTaskDto dto = new RecentTaskDto();
+        dto.setId(task.getId());
+        dto.setName(task.getName());
+        dto.setStatus(task.getStatus());
+        dto.setProgress(task.getProgress());
+        dto.setCreatedAt(task.getCreatedAt());
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- implement dashboard backend module with entities, DTOs, service, and controller
- expose `/api/dashboard` endpoints for stats, trends, and tasks

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881af0b551483269134a476967dffd5