### PR TITLE
Add scheduled task backend module

### DIFF
--- a/backend/src/main/java/com/platform/marketing/task/controller/ScheduledTaskController.java
+++ b/backend/src/main/java/com/platform/marketing/task/controller/ScheduledTaskController.java
@@ -1,0 +1,71 @@
+package com.platform.marketing.task.controller;
+
+import com.platform.marketing.task.dto.ScheduledTaskDto;
+import com.platform.marketing.task.entity.ScheduledTask;
+import com.platform.marketing.task.service.ScheduledTaskService;
+import com.platform.marketing.util.ResponseEntity;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/schedule-task")
+public class ScheduledTaskController {
+
+    private final ScheduledTaskService service;
+
+    public ScheduledTaskController(ScheduledTaskService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/list")
+    @PreAuthorize("hasPermission('task:list')")
+    public ResponseEntity<List<ScheduledTaskDto>> list(@RequestParam(defaultValue = "") String keyword,
+                                                      @RequestParam(defaultValue = "") String status,
+                                                      @RequestParam(required = false) List<String> tags,
+                                                      @RequestParam(defaultValue = "0") int page,
+                                                      @RequestParam(defaultValue = "20") int size) {
+        List<ScheduledTask> tasks = service.search(keyword, status, tags, PageRequest.of(page, size));
+        List<ScheduledTaskDto> dtos = tasks.stream().map(ScheduledTaskDto::fromEntity).collect(java.util.stream.Collectors.toList());
+        return ResponseEntity.success(dtos);
+    }
+
+    @PostMapping("/create")
+    @PreAuthorize("hasPermission('task:create')")
+    public ResponseEntity<Void> create(@RequestBody ScheduledTaskDto dto) {
+        service.create(dto);
+        return ResponseEntity.success(null);
+    }
+
+    @PutMapping("/update")
+    @PreAuthorize("hasPermission('task:update')")
+    public ResponseEntity<Void> update(@RequestBody ScheduledTaskDto dto) {
+        service.update(dto);
+        return ResponseEntity.success(null);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasPermission('task:view')")
+    public ResponseEntity<ScheduledTaskDto> get(@PathVariable String id) {
+        Optional<ScheduledTask> task = service.findById(id);
+        return task.map(t -> ResponseEntity.success(ScheduledTaskDto.fromEntity(t)))
+                .orElse(ResponseEntity.fail(404, "Not Found"));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasPermission('task:delete')")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        service.delete(id);
+        return ResponseEntity.success(null);
+    }
+
+    @PutMapping("/{id}/toggle")
+    @PreAuthorize("hasPermission('task:toggle')")
+    public ResponseEntity<Void> toggle(@PathVariable String id) {
+        service.toggle(id);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/task/dto/ScheduledTaskDto.java
+++ b/backend/src/main/java/com/platform/marketing/task/dto/ScheduledTaskDto.java
@@ -1,0 +1,154 @@
+package com.platform.marketing.task.dto;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.platform.marketing.task.entity.ScheduledTask;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ScheduledTaskDto {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private String id;
+    private String name;
+    private String description;
+    private String cycle;
+    private LocalDateTime startTime;
+    private boolean enabled;
+    private String status;
+    private List<String> actions = new ArrayList<>();
+    private List<String> tags = new ArrayList<>();
+    private LocalDateTime lastRun;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCycle() {
+        return cycle;
+    }
+
+    public void setCycle(String cycle) {
+        this.cycle = cycle;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public List<String> getActions() {
+        return actions;
+    }
+
+    public void setActions(List<String> actions) {
+        this.actions = actions;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public LocalDateTime getLastRun() {
+        return lastRun;
+    }
+
+    public void setLastRun(LocalDateTime lastRun) {
+        this.lastRun = lastRun;
+    }
+
+    public static ScheduledTaskDto fromEntity(ScheduledTask entity) {
+        ScheduledTaskDto dto = new ScheduledTaskDto();
+        dto.setId(entity.getId());
+        dto.setName(entity.getName());
+        dto.setDescription(entity.getDescription());
+        dto.setCycle(entity.getCycle());
+        dto.setStartTime(entity.getStartTime());
+        dto.setEnabled(entity.isEnabled());
+        dto.setStatus(entity.getStatus());
+        String actionsStr = entity.getActions();
+        if (actionsStr != null && !actionsStr.trim().isEmpty()) {
+            try {
+                dto.setActions(mapper.readValue(actionsStr, new TypeReference<List<String>>(){}));
+            } catch (Exception e) {
+                dto.setActions(Arrays.asList(actionsStr.split("\n")));
+            }
+        }
+        String tagsStr = entity.getTags();
+        if (tagsStr != null && !tagsStr.trim().isEmpty()) {
+            dto.setTags(Arrays.asList(tagsStr.split(",")));
+        }
+        dto.setLastRun(entity.getLastRun());
+        return dto;
+    }
+
+    public static void copyToEntity(ScheduledTaskDto dto, ScheduledTask entity) {
+        entity.setName(dto.getName());
+        entity.setDescription(dto.getDescription());
+        entity.setCycle(dto.getCycle());
+        entity.setStartTime(dto.getStartTime());
+        entity.setEnabled(dto.isEnabled());
+        entity.setStatus(dto.getStatus());
+        if (dto.getActions() != null && !dto.getActions().isEmpty()) {
+            try {
+                entity.setActions(mapper.writeValueAsString(dto.getActions()));
+            } catch (Exception e) {
+                entity.setActions(String.join("\n", dto.getActions()));
+            }
+        } else {
+            entity.setActions("[]");
+        }
+        if (dto.getTags() != null && !dto.getTags().isEmpty()) {
+            entity.setTags(String.join(",", dto.getTags()));
+        } else {
+            entity.setTags("");
+        }
+        entity.setLastRun(dto.getLastRun());
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/task/entity/ScheduledTask.java
+++ b/backend/src/main/java/com/platform/marketing/task/entity/ScheduledTask.java
@@ -1,0 +1,134 @@
+package com.platform.marketing.task.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "scheduled_task")
+public class ScheduledTask {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(length = 36)
+    private String id;
+
+    private String name;
+
+    @Lob
+    private String description;
+
+    private String cycle;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    private boolean enabled;
+
+    private String status;
+
+    @Lob
+    private String actions;
+
+    private String tags;
+
+    @Column(name = "last_run")
+    private LocalDateTime lastRun;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCycle() {
+        return cycle;
+    }
+
+    public void setCycle(String cycle) {
+        this.cycle = cycle;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getActions() {
+        return actions;
+    }
+
+    public void setActions(String actions) {
+        this.actions = actions;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    public LocalDateTime getLastRun() {
+        return lastRun;
+    }
+
+    public void setLastRun(LocalDateTime lastRun) {
+        this.lastRun = lastRun;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/task/repository/ScheduledTaskRepository.java
+++ b/backend/src/main/java/com/platform/marketing/task/repository/ScheduledTaskRepository.java
@@ -1,0 +1,10 @@
+package com.platform.marketing.task.repository;
+
+import com.platform.marketing.task.entity.ScheduledTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, String>, JpaSpecificationExecutor<ScheduledTask> {
+}

--- a/backend/src/main/java/com/platform/marketing/task/service/ScheduledTaskService.java
+++ b/backend/src/main/java/com/platform/marketing/task/service/ScheduledTaskService.java
@@ -1,0 +1,22 @@
+package com.platform.marketing.task.service;
+
+import com.platform.marketing.task.dto.ScheduledTaskDto;
+import com.platform.marketing.task.entity.ScheduledTask;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduledTaskService {
+    List<ScheduledTask> search(String keyword, String status, List<String> tags, Pageable pageable);
+
+    ScheduledTask create(ScheduledTaskDto taskDto);
+
+    ScheduledTask update(ScheduledTaskDto taskDto);
+
+    Optional<ScheduledTask> findById(String id);
+
+    void delete(String id);
+
+    void toggle(String id);
+}

--- a/backend/src/main/java/com/platform/marketing/task/service/impl/ScheduledTaskServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/task/service/impl/ScheduledTaskServiceImpl.java
@@ -1,0 +1,94 @@
+package com.platform.marketing.task.service.impl;
+
+import com.platform.marketing.task.dto.ScheduledTaskDto;
+import com.platform.marketing.task.entity.ScheduledTask;
+import com.platform.marketing.task.repository.ScheduledTaskRepository;
+import com.platform.marketing.task.service.ScheduledTaskService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ScheduledTaskServiceImpl implements ScheduledTaskService {
+
+    private final ScheduledTaskRepository repository;
+
+    public ScheduledTaskServiceImpl(ScheduledTaskRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<ScheduledTask> search(String keyword, String status, List<String> tags, Pageable pageable) {
+        Specification<ScheduledTask> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (keyword != null && !keyword.trim().isEmpty()) {
+                String like = "%" + keyword.toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("name")), like),
+                        cb.like(cb.lower(root.get("description")), like)
+                ));
+            }
+            if (status != null && !status.trim().isEmpty()) {
+                predicates.add(cb.equal(root.get("status"), status));
+            }
+            if (tags != null && !tags.isEmpty()) {
+                for (String tag : tags) {
+                    predicates.add(cb.like(root.get("tags"), "%" + tag + "%"));
+                }
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        if (pageable == null) {
+            return repository.findAll(spec);
+        }
+        return repository.findAll(spec, pageable).getContent();
+    }
+
+    @Override
+    @Transactional
+    public ScheduledTask create(ScheduledTaskDto taskDto) {
+        ScheduledTask entity = new ScheduledTask();
+        ScheduledTaskDto.copyToEntity(taskDto, entity);
+        return repository.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public ScheduledTask update(ScheduledTaskDto taskDto) {
+        ScheduledTask existing = repository.findById(taskDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Task not found"));
+        ScheduledTaskDto.copyToEntity(taskDto, existing);
+        return repository.save(existing);
+    }
+
+    @Override
+    public Optional<ScheduledTask> findById(String id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        repository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void toggle(String id) {
+        repository.findById(id).ifPresent(task -> {
+            task.setEnabled(!task.isEnabled());
+            if (task.isEnabled()) {
+                task.setStatus("running");
+            } else {
+                task.setStatus("paused");
+            }
+            repository.save(task);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement scheduled task entity, dto, repository
- implement service layer with basic CRUD and toggle status
- expose controller endpoints secured with permissions

## Testing
- `mvn -f backend/pom.xml test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881b0f362cc83268622f5aba1cf001e