### PR TITLE
Implement system settings API module

### DIFF
--- a/backend/src/main/java/com/platform/marketing/system/controller/SystemSettingsController.java
+++ b/backend/src/main/java/com/platform/marketing/system/controller/SystemSettingsController.java
@@ -1,0 +1,45 @@
+package com.platform.marketing.system.controller;
+
+import com.platform.marketing.system.dto.*;
+import com.platform.marketing.system.service.SystemSettingsService;
+import com.platform.marketing.util.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/system/settings")
+public class SystemSettingsController {
+
+    private final SystemSettingsService service;
+
+    public SystemSettingsController(SystemSettingsService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/")
+    @PreAuthorize("hasPermission('settings:view')")
+    public ResponseEntity<SystemSettingsDto> getSettings() {
+        return ResponseEntity.success(service.getSettings());
+    }
+
+    @PostMapping("/basic")
+    @PreAuthorize("hasPermission('settings:update')")
+    public ResponseEntity<Void> saveBasic(@RequestBody BasicSettingsDto dto) {
+        service.saveBasicSettings(dto);
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/notify")
+    @PreAuthorize("hasPermission('settings:update')")
+    public ResponseEntity<Void> saveNotify(@RequestBody NotifySettingsDto dto) {
+        service.saveNotificationSettings(dto);
+        return ResponseEntity.success(null);
+    }
+
+    @PostMapping("/security")
+    @PreAuthorize("hasPermission('settings:update')")
+    public ResponseEntity<Void> saveSecurity(@RequestBody SecuritySettingsDto dto) {
+        service.saveSecuritySettings(dto);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/system/dto/BasicSettingsDto.java
+++ b/backend/src/main/java/com/platform/marketing/system/dto/BasicSettingsDto.java
@@ -1,0 +1,20 @@
+package com.platform.marketing.system.dto;
+
+public class BasicSettingsDto {
+    private String siteName;
+    private String brandColor;
+    private String logoUrl;
+    private String language;
+
+    public String getSiteName() { return siteName; }
+    public void setSiteName(String siteName) { this.siteName = siteName; }
+
+    public String getBrandColor() { return brandColor; }
+    public void setBrandColor(String brandColor) { this.brandColor = brandColor; }
+
+    public String getLogoUrl() { return logoUrl; }
+    public void setLogoUrl(String logoUrl) { this.logoUrl = logoUrl; }
+
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+}

--- a/backend/src/main/java/com/platform/marketing/system/dto/NotifySettingsDto.java
+++ b/backend/src/main/java/com/platform/marketing/system/dto/NotifySettingsDto.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.system.dto;
+
+public class NotifySettingsDto {
+    private boolean enabled;
+    private String type;
+    private String channel;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getChannel() { return channel; }
+    public void setChannel(String channel) { this.channel = channel; }
+}

--- a/backend/src/main/java/com/platform/marketing/system/dto/SecuritySettingsDto.java
+++ b/backend/src/main/java/com/platform/marketing/system/dto/SecuritySettingsDto.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.system.dto;
+
+public class SecuritySettingsDto {
+    private String passwordStrength;
+    private Integer deviceLimit;
+    private boolean twoFactor;
+
+    public String getPasswordStrength() { return passwordStrength; }
+    public void setPasswordStrength(String passwordStrength) { this.passwordStrength = passwordStrength; }
+
+    public Integer getDeviceLimit() { return deviceLimit; }
+    public void setDeviceLimit(Integer deviceLimit) { this.deviceLimit = deviceLimit; }
+
+    public boolean isTwoFactor() { return twoFactor; }
+    public void setTwoFactor(boolean twoFactor) { this.twoFactor = twoFactor; }
+}

--- a/backend/src/main/java/com/platform/marketing/system/dto/SystemSettingsDto.java
+++ b/backend/src/main/java/com/platform/marketing/system/dto/SystemSettingsDto.java
@@ -1,0 +1,16 @@
+package com.platform.marketing.system.dto;
+
+public class SystemSettingsDto {
+    private BasicSettingsDto basicSettings;
+    private NotifySettingsDto notificationSettings;
+    private SecuritySettingsDto securitySettings;
+
+    public BasicSettingsDto getBasicSettings() { return basicSettings; }
+    public void setBasicSettings(BasicSettingsDto basicSettings) { this.basicSettings = basicSettings; }
+
+    public NotifySettingsDto getNotificationSettings() { return notificationSettings; }
+    public void setNotificationSettings(NotifySettingsDto notificationSettings) { this.notificationSettings = notificationSettings; }
+
+    public SecuritySettingsDto getSecuritySettings() { return securitySettings; }
+    public void setSecuritySettings(SecuritySettingsDto securitySettings) { this.securitySettings = securitySettings; }
+}

--- a/backend/src/main/java/com/platform/marketing/system/entity/SystemSettings.java
+++ b/backend/src/main/java/com/platform/marketing/system/entity/SystemSettings.java
@@ -1,0 +1,49 @@
+package com.platform.marketing.system.entity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "system_settings")
+public class SystemSettings {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    @Lob
+    @Column(name = "basic_settings", columnDefinition = "text")
+    private String basicSettings;
+
+    @Lob
+    @Column(name = "notification_settings", columnDefinition = "text")
+    private String notificationSettings;
+
+    @Lob
+    @Column(name = "security_settings", columnDefinition = "text")
+    private String securitySettings;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() { this.updatedAt = LocalDateTime.now(); }
+
+    @PreUpdate
+    public void preUpdate() { this.updatedAt = LocalDateTime.now(); }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getBasicSettings() { return basicSettings; }
+    public void setBasicSettings(String basicSettings) { this.basicSettings = basicSettings; }
+
+    public String getNotificationSettings() { return notificationSettings; }
+    public void setNotificationSettings(String notificationSettings) { this.notificationSettings = notificationSettings; }
+
+    public String getSecuritySettings() { return securitySettings; }
+    public void setSecuritySettings(String securitySettings) { this.securitySettings = securitySettings; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/platform/marketing/system/repository/SystemSettingsRepository.java
+++ b/backend/src/main/java/com/platform/marketing/system/repository/SystemSettingsRepository.java
@@ -1,0 +1,9 @@
+package com.platform.marketing.system.repository;
+
+import com.platform.marketing.system.entity.SystemSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SystemSettingsRepository extends JpaRepository<SystemSettings, String> {
+}

--- a/backend/src/main/java/com/platform/marketing/system/service/SystemSettingsService.java
+++ b/backend/src/main/java/com/platform/marketing/system/service/SystemSettingsService.java
@@ -1,0 +1,10 @@
+package com.platform.marketing.system.service;
+
+import com.platform.marketing.system.dto.*;
+
+public interface SystemSettingsService {
+    SystemSettingsDto getSettings();
+    void saveBasicSettings(BasicSettingsDto dto);
+    void saveNotificationSettings(NotifySettingsDto dto);
+    void saveSecuritySettings(SecuritySettingsDto dto);
+}

--- a/backend/src/main/java/com/platform/marketing/system/service/impl/SystemSettingsServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/system/service/impl/SystemSettingsServiceImpl.java
@@ -1,0 +1,89 @@
+package com.platform.marketing.system.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.platform.marketing.system.dto.*;
+import com.platform.marketing.system.entity.SystemSettings;
+import com.platform.marketing.system.repository.SystemSettingsRepository;
+import com.platform.marketing.system.service.SystemSettingsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SystemSettingsServiceImpl implements SystemSettingsService {
+
+    private final SystemSettingsRepository repository;
+    private final ObjectMapper mapper;
+
+    public SystemSettingsServiceImpl(SystemSettingsRepository repository, ObjectMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    private SystemSettings getEntity() {
+        return repository.findById("default").orElseGet(() -> {
+            SystemSettings s = new SystemSettings();
+            s.setId("default");
+            s.setBasicSettings("{}");
+            s.setNotificationSettings("{}");
+            s.setSecuritySettings("{}");
+            return repository.save(s);
+        });
+    }
+
+    private <T> T read(String json, Class<T> clazz) {
+        try {
+            if (json == null || json.isEmpty()) {
+                return clazz.getConstructor().newInstance();
+            }
+            return mapper.readValue(json, clazz);
+        } catch (Exception e) {
+            try {
+                return clazz.getConstructor().newInstance();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    private String write(Object obj) {
+        try {
+            return mapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public SystemSettingsDto getSettings() {
+        SystemSettings entity = getEntity();
+        SystemSettingsDto dto = new SystemSettingsDto();
+        dto.setBasicSettings(read(entity.getBasicSettings(), BasicSettingsDto.class));
+        dto.setNotificationSettings(read(entity.getNotificationSettings(), NotifySettingsDto.class));
+        dto.setSecuritySettings(read(entity.getSecuritySettings(), SecuritySettingsDto.class));
+        return dto;
+    }
+
+    @Override
+    @Transactional
+    public void saveBasicSettings(BasicSettingsDto dto) {
+        SystemSettings entity = getEntity();
+        entity.setBasicSettings(write(dto));
+        repository.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public void saveNotificationSettings(NotifySettingsDto dto) {
+        SystemSettings entity = getEntity();
+        entity.setNotificationSettings(write(dto));
+        repository.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public void saveSecuritySettings(SecuritySettingsDto dto) {
+        SystemSettings entity = getEntity();
+        entity.setSecuritySettings(write(dto));
+        repository.save(entity);
+    }
+}


### PR DESCRIPTION
## Summary
- add backend module for system settings with entity, repository and service
- expose `/api/system/settings` endpoints for CRUD of basic, notification and security settings

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881ccaafb148326a972f4121fa271a9