### PR TITLE
Add permission binding support when creating/updating roles

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/RoleController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/RoleController.java
@@ -1,6 +1,7 @@
 package com.platform.marketing.controller;
 
 import com.platform.marketing.dto.PermissionRequest;
+import com.platform.marketing.dto.RoleDto;
 import com.platform.marketing.entity.Role;
 import com.platform.marketing.service.RoleService;
 import com.platform.marketing.util.ResponseEntity;
@@ -27,15 +28,16 @@ public class RoleController {
 
     @PostMapping
     @PreAuthorize("hasPermission('role:create')")
-    public ResponseEntity<Role> create(@RequestBody Role role) {
-        role.setId(java.util.UUID.randomUUID().toString());
-        return ResponseEntity.success(roleService.create(role));
+    public ResponseEntity<RoleDto> create(@RequestBody RoleDto dto) {
+        RoleDto created = roleService.createRoleWithPermissions(dto);
+        return ResponseEntity.success(created);
     }
 
     @PostMapping("/update")
     @PreAuthorize("hasPermission('role:update')")
-    public ResponseEntity<Role> updateRole(@RequestBody Role role) {
-        return ResponseEntity.success(roleService.update(role.getId(), role));
+    public ResponseEntity<RoleDto> updateRole(@RequestBody RoleDto dto) {
+        RoleDto updated = roleService.updateRoleWithPermissions(dto);
+        return ResponseEntity.success(updated);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/platform/marketing/dto/RoleDto.java
+++ b/backend/src/main/java/com/platform/marketing/dto/RoleDto.java
@@ -1,0 +1,67 @@
+package com.platform.marketing.dto;
+
+import com.platform.marketing.entity.Role;
+import java.util.List;
+
+public class RoleDto {
+    private String id;
+    private String name;
+    private String description;
+    private boolean status = true;
+    private List<String> permissionIds;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+
+    public List<String> getPermissionIds() {
+        return permissionIds;
+    }
+
+    public void setPermissionIds(List<String> permissionIds) {
+        this.permissionIds = permissionIds;
+    }
+
+    public static RoleDto fromEntity(Role role) {
+        RoleDto dto = new RoleDto();
+        dto.setId(role.getId());
+        dto.setName(role.getName());
+        dto.setDescription(role.getDescription());
+        dto.setStatus(role.isStatus());
+        return dto;
+    }
+
+    public static void copyToEntity(RoleDto dto, Role role) {
+        role.setName(dto.getName());
+        role.setDescription(dto.getDescription());
+        role.setStatus(dto.isStatus());
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/repository/RolePermissionRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/RolePermissionRepository.java
@@ -11,4 +11,9 @@ import java.util.List;
 public interface RolePermissionRepository extends JpaRepository<RolePermission, RolePermissionId> {
     List<RolePermission> findByIdRoleId(String roleId);
     void deleteByIdRoleId(String roleId);
+
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.transaction.annotation.Transactional
+    @org.springframework.data.jpa.repository.Query("DELETE FROM RolePermission rp WHERE rp.id.roleId = :roleId")
+    void deleteByRoleId(@org.springframework.data.repository.query.Param("roleId") String roleId);
 }


### PR DESCRIPTION
## Summary
- support receiving permissionIds in role APIs
- maintain role_permission table automatically
- expose helper DTO to work with permissions

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881ed6cf3a08326a8d58187051971b7