### PR TITLE
Add module filter for permissions

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,0 +1,3 @@
+-- SQL schema for permission module
+ALTER TABLE sys_permission
+    ADD COLUMN `module` varchar(255) DEFAULT NULL;

--- a/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
@@ -25,10 +25,11 @@ public class PermissionController {
     @PreAuthorize("hasPermission('permission:list')")
     public ResponseEntity<ResponsePageDataEntity<Permission>> list(@RequestParam(defaultValue = "") String keyword,
                                                                    @RequestParam(defaultValue = "") String type,
+                                                                   @RequestParam(defaultValue = "") String module,
                                                                    @RequestParam(required = false) Boolean status,
                                                                    @RequestParam(defaultValue = "0") int page,
                                                                    @RequestParam(defaultValue = "10") int size) {
-        Page<Permission> p = permissionService.search(keyword, type, status, PageRequest.of(page, size));
+        Page<Permission> p = permissionService.search(keyword, type, module, status, PageRequest.of(page, size));
         return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
     }
 

--- a/backend/src/main/java/com/platform/marketing/dto/PermissionTreeNode.java
+++ b/backend/src/main/java/com/platform/marketing/dto/PermissionTreeNode.java
@@ -13,6 +13,7 @@ public class PermissionTreeNode {
     private String method;
     private boolean status;
     private String description;
+    private String module;
     private List<PermissionTreeNode> children = new ArrayList<>();
 
     public PermissionTreeNode() {}
@@ -42,6 +43,8 @@ public class PermissionTreeNode {
     public void setStatus(boolean status) { this.status = status; }
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+    public String getModule() { return module; }
+    public void setModule(String module) { this.module = module; }
     public List<PermissionTreeNode> getChildren() { return children; }
     public void setChildren(List<PermissionTreeNode> children) { this.children = children; }
 }

--- a/backend/src/main/java/com/platform/marketing/entity/Permission.java
+++ b/backend/src/main/java/com/platform/marketing/entity/Permission.java
@@ -43,6 +43,12 @@ public class Permission {
 
     private boolean status = true;
 
+    /**
+     * Module to which this permission belongs
+     */
+    @Column(name = "module")
+    private String module;
+
     @Column(name = "created_by")
     private String createdBy;
 
@@ -129,6 +135,14 @@ public class Permission {
 
     public void setMethod(String method) {
         this.method = method;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public void setModule(String module) {
+        this.module = module;
     }
 
     public boolean isStatus() {

--- a/backend/src/main/java/com/platform/marketing/repository/PermissionRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/PermissionRepository.java
@@ -26,9 +26,11 @@ public interface PermissionRepository extends JpaRepository<Permission, String> 
            "WHERE (:keyword = '' OR lower(p.name) LIKE lower(concat('%', :keyword, '%')) " +
            "OR lower(p.code) LIKE lower(concat('%', :keyword, '%'))) " +
            "AND (:type = '' OR p.type = :type) " +
+           "AND (:module = '' OR lower(p.module) LIKE lower(concat('%', :module, '%'))) " +
            "AND (:status IS NULL OR p.status = :status)")
     Page<Permission> search(@Param("keyword") String keyword,
                             @Param("type") String type,
+                            @Param("module") String module,
                             @Param("status") Boolean status,
                             Pageable pageable);
 

--- a/backend/src/main/java/com/platform/marketing/service/PermissionService.java
+++ b/backend/src/main/java/com/platform/marketing/service/PermissionService.java
@@ -18,7 +18,7 @@ public interface PermissionService {
 
     void updateStatus(String id, boolean status);
 
-    Page<Permission> search(String keyword, String type, Boolean status, Pageable pageable);
+    Page<Permission> search(String keyword, String type, String module, Boolean status, Pageable pageable);
 
     List<com.platform.marketing.dto.PermissionTreeNode> getTree();
 }

--- a/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
@@ -28,10 +28,11 @@ public class PermissionServiceImpl implements PermissionService {
     }
 
     @Override
-    public Page<Permission> search(String keyword, String type, Boolean status, Pageable pageable) {
+    public Page<Permission> search(String keyword, String type, String module, Boolean status, Pageable pageable) {
         if (keyword == null) keyword = "";
         if (type == null) type = "";
-        return permissionRepository.search(keyword, type, status, pageable);
+        if (module == null) module = "";
+        return permissionRepository.search(keyword, type, module, status, pageable);
     }
 
     @Override
@@ -67,6 +68,7 @@ public class PermissionServiceImpl implements PermissionService {
         existing.setUrl(permission.getUrl());
         existing.setMethod(permission.getMethod());
         existing.setGroup(permission.getGroup());
+        existing.setModule(permission.getModule());
         existing.setStatus(permission.isStatus());
         existing.setUpdatedBy(currentUser());
         return permissionRepository.save(existing);
@@ -109,6 +111,7 @@ public class PermissionServiceImpl implements PermissionService {
             node.setMethod(p.getMethod());
             node.setStatus(p.isStatus());
             node.setDescription(p.getDescription());
+            node.setModule(p.getModule());
             map.put(p.getId(), node);
         }
         List<com.platform.marketing.dto.PermissionTreeNode> roots = new java.util.ArrayList<>();


### PR DESCRIPTION
## Summary
- add `module` column to Permission entity
- support `module` when listing permissions
- persist the new field in update logic and permission trees
- expose the field in DTOs
- provide SQL snippet to add the column

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7cb39488326b082ba116adc6fb2