### PR TITLE
Add module filter for permissions

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,0 +1,3 @@
+-- SQL schema for permission module
+ALTER TABLE sys_permission
+    ADD COLUMN `module` varchar(255) DEFAULT NULL;

--- a/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/PermissionController.java
@@ -25,10 +25,11 @@ public class PermissionController {
     @PreAuthorize("hasPermission('permission:list')")
     public ResponseEntity<ResponsePageDataEntity<Permission>> list(@RequestParam(defaultValue = "") String keyword,
                                                                    @RequestParam(defaultValue = "") String type,
+                                                                   @RequestParam(defaultValue = "") String module,
                                                                    @RequestParam(required = false) Boolean status,
                                                                    @RequestParam(defaultValue = "0") int page,
                                                                    @RequestParam(defaultValue = "10") int size) {
-        Page<Permission> p = permissionService.search(keyword, type, status, PageRequest.of(page, size));
+        Page<Permission> p = permissionService.search(keyword, type, module, status, PageRequest.of(page, size));
         return ResponseEntity.success(new ResponsePageDataEntity<>(p.getTotalElements(), p.getContent()));
     }
 

--- a/backend/src/main/java/com/platform/marketing/dto/PermissionTreeNode.java
+++ b/backend/src/main/java/com/platform/marketing/dto/PermissionTreeNode.java
@@ -13,6 +13,7 @@ public class PermissionTreeNode {
     private String method;
     private boolean status;
     private String description;
+    private String module;
     private List<PermissionTreeNode> children = new ArrayList<>();
 
     public PermissionTreeNode() {}
@@ -42,6 +43,8 @@ public class PermissionTreeNode {
     public void setStatus(boolean status) { this.status = status; }
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+    public String getModule() { return module; }
+    public void setModule(String module) { this.module = module; }
     public List<PermissionTreeNode> getChildren() { return children; }
     public void setChildren(List<PermissionTreeNode> children) { this.children = children; }
 }

--- a/backend/src/main/java/com/platform/marketing/entity/Permission.java
+++ b/backend/src/main/java/com/platform/marketing/entity/Permission.java
@@ -43,6 +43,12 @@ public class Permission {
 
     private boolean status = true;
 
+    /**
+     * Module to which this permission belongs
+     */
+    @Column(name = "module")
+    private String module;
+
     @Column(name = "created_by")
     private String createdBy;
 
@@ -129,6 +135,14 @@ public class Permission {
 
     public void setMethod(String method) {
         this.method = method;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public void setModule(String module) {
+        this.module = module;
     }
 
     public boolean isStatus() {

--- a/backend/src/main/java/com/platform/marketing/repository/PermissionRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/PermissionRepository.java
@@ -26,9 +26,11 @@ public interface PermissionRepository extends JpaRepository<Permission, String> 
            "WHERE (:keyword = '' OR lower(p.name) LIKE lower(concat('%', :keyword, '%')) " +
            "OR lower(p.code) LIKE lower(concat('%', :keyword, '%'))) " +
            "AND (:type = '' OR p.type = :type) " +
+           "AND (:module = '' OR lower(p.module) LIKE lower(concat('%', :module, '%'))) " +
            "AND (:status IS NULL OR p.status = :status)")
     Page<Permission> search(@Param("keyword") String keyword,
                             @Param("type") String type,
+                            @Param("module") String module,
                             @Param("status") Boolean status,
                             Pageable pageable);
 

--- a/backend/src/main/java/com/platform/marketing/service/PermissionService.java
+++ b/backend/src/main/java/com/platform/marketing/service/PermissionService.java
@@ -18,7 +18,7 @@ public interface PermissionService {
 
     void updateStatus(String id, boolean status);
 
-    Page<Permission> search(String keyword, String type, Boolean status, Pageable pageable);
+    Page<Permission> search(String keyword, String type, String module, Boolean status, Pageable pageable);
 
     List<com.platform.marketing.dto.PermissionTreeNode> getTree();
 }

--- a/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/PermissionServiceImpl.java
@@ -28,10 +28,11 @@ public class PermissionServiceImpl implements PermissionService {
     }
 
     @Override
-    public Page<Permission> search(String keyword, String type, Boolean status, Pageable pageable) {
+    public Page<Permission> search(String keyword, String type, String module, Boolean status, Pageable pageable) {
         if (keyword == null) keyword = "";
         if (type == null) type = "";
-        return permissionRepository.search(keyword, type, status, pageable);
+        if (module == null) module = "";
+        return permissionRepository.search(keyword, type, module, status, pageable);
     }
 
     @Override
@@ -67,6 +68,7 @@ public class PermissionServiceImpl implements PermissionService {
         existing.setUrl(permission.getUrl());
         existing.setMethod(permission.getMethod());
         existing.setGroup(permission.getGroup());
+        existing.setModule(permission.getModule());
         existing.setStatus(permission.isStatus());
         existing.setUpdatedBy(currentUser());
         return permissionRepository.save(existing);
@@ -97,34 +99,50 @@ public class PermissionServiceImpl implements PermissionService {
     @Override
     public List<com.platform.marketing.dto.PermissionTreeNode> getTree() {
         List<Permission> all = permissionRepository.findAll();
-        java.util.Map<String, com.platform.marketing.dto.PermissionTreeNode> map = new java.util.HashMap<>();
-        for (Permission p : all) {
-            com.platform.marketing.dto.PermissionTreeNode node = new com.platform.marketing.dto.PermissionTreeNode();
-            node.setId(p.getId());
-            node.setName(p.getName());
-            node.setCode(p.getCode());
-            node.setParentId(p.getParentId());
-            node.setType(p.getType());
-            node.setUrl(p.getUrl());
-            node.setMethod(p.getMethod());
-            node.setStatus(p.isStatus());
-            node.setDescription(p.getDescription());
-            map.put(p.getId(), node);
-        }
-        List<com.platform.marketing.dto.PermissionTreeNode> roots = new java.util.ArrayList<>();
-        for (com.platform.marketing.dto.PermissionTreeNode n : map.values()) {
-            if (n.getParentId() == null || n.getParentId().isEmpty()) {
-                roots.add(n);
-            } else {
-                com.platform.marketing.dto.PermissionTreeNode parent = map.get(n.getParentId());
-                if (parent != null) {
-                    parent.getChildren().add(n);
+
+        java.util.Map<String, java.util.List<Permission>> byModule =
+                all.stream().collect(java.util.stream.Collectors.groupingBy(p ->
+                        p.getModule() == null ? "默认模块" : p.getModule()));
+
+        java.util.List<com.platform.marketing.dto.PermissionTreeNode> modules = new java.util.ArrayList<>();
+
+        for (java.util.Map.Entry<String, java.util.List<Permission>> entry : byModule.entrySet()) {
+            String moduleName = entry.getKey();
+            com.platform.marketing.dto.PermissionTreeNode moduleRoot = new com.platform.marketing.dto.PermissionTreeNode();
+            moduleRoot.setId("module:" + moduleName);
+            moduleRoot.setName(moduleName);
+            moduleRoot.setModule(moduleName);
+            moduleRoot.setType("module");
+
+            java.util.Map<String, com.platform.marketing.dto.PermissionTreeNode> map = new java.util.HashMap<>();
+            for (Permission p : entry.getValue()) {
+                com.platform.marketing.dto.PermissionTreeNode node = new com.platform.marketing.dto.PermissionTreeNode();
+                node.setId(p.getId());
+                node.setName(p.getName());
+                node.setCode(p.getCode());
+                node.setParentId(p.getParentId());
+                node.setType(p.getType());
+                node.setUrl(p.getUrl());
+                node.setMethod(p.getMethod());
+                node.setStatus(p.isStatus());
+                node.setDescription(p.getDescription());
+                node.setModule(p.getModule());
+                map.put(p.getId(), node);
+            }
+
+            for (com.platform.marketing.dto.PermissionTreeNode n : map.values()) {
+                if (n.getParentId() == null || n.getParentId().isEmpty() || !map.containsKey(n.getParentId())) {
+                    moduleRoot.getChildren().add(n);
                 } else {
-                    roots.add(n);
+                    com.platform.marketing.dto.PermissionTreeNode parent = map.get(n.getParentId());
+                    parent.getChildren().add(n);
                 }
             }
+
+            modules.add(moduleRoot);
         }
-        return roots;
+
+        return modules;
     }
 
     private String currentUser() {

--- a/frontend/src/api/permission.js
+++ b/frontend/src/api/permission.js
@@ -3,7 +3,7 @@ import request from '../utils/request'
 /**
  * 查询权限分页列表
  * GET /v1/permissions
- * 支持查询参数：page, size, keyword, type, status
+ * 支持查询参数：page, size, keyword, type, module, status
  */
 export function fetchPermissions(params) {
   return request({

--- a/frontend/src/views/permission/PermissionConfig.vue
+++ b/frontend/src/views/permission/PermissionConfig.vue
@@ -42,6 +42,11 @@
             <el-option label="按钮" value="按钮" />
           </el-select>
         </el-form-item>
+        <el-form-item label="模块">
+          <el-select v-model="form.module" placeholder="请选择" style="width: 100%">
+            <el-option v-for="m in moduleOptions" :key="m.value" :label="m.label" :value="m.value" />
+          </el-select>
+        </el-form-item>
         <el-form-item label="上级权限">
           <el-tree-select
             v-model="form.parent_id"
@@ -79,12 +84,14 @@ const dialogVisible = ref(false)
 const isEdit = ref(false)
 const saving = ref(false)
 const treeRef = ref()
+const moduleOptions = ref([])
 
 const form = reactive({
   id: '',
   name: '',
   code: '',
   type: '',
+  module: '',
   parent_id: ''
 })
 
@@ -92,13 +99,15 @@ onMounted(loadTree)
 
 function loadTree() {
   fetchPermissionTree().then(res => {
-    treeData.value = res.data || []
+    const data = res.data || []
+    treeData.value = data.map(m => ({ ...m, disabled: true }))
+    moduleOptions.value = data.map(m => ({ label: m.name, value: m.module }))
   })
 }
 
 function openAddDialog() {
   isEdit.value = false
-  Object.assign(form, { id: '', name: '', code: '', type: '', parent_id: '' })
+  Object.assign(form, { id: '', name: '', code: '', type: '', module: '', parent_id: '' })
   dialogVisible.value = true
 }
 

--- a/frontend/src/views/permission/PermissionListTab.vue
+++ b/frontend/src/views/permission/PermissionListTab.vue
@@ -8,6 +8,7 @@
           <el-option label="菜单" value="菜单" />
           <el-option label="按钮" value="按钮" />
         </el-select>
+        <el-input v-model="searchModule" placeholder="模块" clearable style="width: 120px" />
         <el-select v-model="searchStatus" placeholder="状态" clearable style="width: 120px">
           <el-option label="启用" :value="true" />
           <el-option label="禁用" :value="false" />
@@ -32,6 +33,7 @@
       <el-table-column prop="name" label="权限名称" />
       <el-table-column prop="code" label="权限编码" />
       <el-table-column prop="type" label="类型" width="80" />
+      <el-table-column prop="module" label="模块" width="120" />
       <el-table-column prop="status" label="状态" width="100">
         <template #default="{ row }">
           <el-switch
@@ -82,6 +84,11 @@
             <el-option label="按钮" value="按钮" />
           </el-select>
         </el-form-item>
+        <el-form-item label="模块">
+          <el-select v-model="form.module" placeholder="请选择" style="width: 100%">
+            <el-option v-for="m in moduleOptions" :key="m.value" :label="m.label" :value="m.value" />
+          </el-select>
+        </el-form-item>
         <el-form-item label="上级权限">
           <el-tree-select
             v-model="form.parent_id"
@@ -125,6 +132,7 @@ const page = ref(1)
 const size = ref(10)
 const searchKeyword = ref('')
 const searchType = ref('')
+const searchModule = ref('')
 const searchStatus = ref()
 const selection = ref([])
 const loading = ref(false)
@@ -132,12 +140,14 @@ const saving = ref(false)
 const drawerVisible = ref(false)
 const isEdit = ref(false)
 const treeOptions = ref([])
+const moduleOptions = ref([])
 
 const form = reactive({
   id: '',
   name: '',
   code: '',
   type: '',
+  module: '',
   parent_id: '',
   status: true
 })
@@ -154,6 +164,7 @@ function fetchData() {
     size: size.value,
     keyword: searchKeyword.value,
     type: searchType.value,
+    module: searchModule.value,
     status: searchStatus.value
   })
     .then(res => {
@@ -165,7 +176,9 @@ function fetchData() {
 
 function loadTree() {
   fetchPermissionTree().then(res => {
-    treeOptions.value = res.data || []
+    const data = res.data || []
+    treeOptions.value = data.map(m => ({ ...m, disabled: true }))
+    moduleOptions.value = data.map(m => ({ label: m.name, value: m.module }))
   })
 }
 
@@ -179,6 +192,7 @@ function openDialog(edit = false, data = null) {
       name: '',
       code: '',
       type: '',
+      module: '',
       parent_id: '',
       status: true
     })

--- a/frontend/src/views/permission/RoleManagement.vue
+++ b/frontend/src/views/permission/RoleManagement.vue
@@ -105,7 +105,8 @@ function loadRoles() {
 
 function loadPermissionTree() {
   fetchPermissionTree().then((res) => {
-    treeData.value = res.data || [];
+    const data = res.data || [];
+    treeData.value = data.map(m => ({ ...m, disabled: true }));
   });
 }
 


### PR DESCRIPTION
## Summary
- add `module` column to Permission entity
- support `module` when listing permissions
- persist the new field in update logic and permission trees
- expose the field in DTOs
- provide SQL snippet to add the column
- group permission tree data by module and expose new module field in UI
- show module column and filter on the permission list
- allow selecting module when editing permissions

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881f7cb39488326b082ba116adc6fb2