### PR TITLE
Add user role-menu management module

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,3 +1,17 @@
 -- SQL schema for permission module
 ALTER TABLE sys_permission
     ADD COLUMN `module` varchar(255) DEFAULT NULL;
+
+-- table for role and menu mapping
+CREATE TABLE IF NOT EXISTS role_menu (
+    role_id varchar(36) NOT NULL,
+    menu_id varchar(36) NOT NULL,
+    PRIMARY KEY (role_id, menu_id)
+);
+
+-- table for user and role mapping (if not exists)
+CREATE TABLE IF NOT EXISTS user_role (
+    user_id varchar(36) NOT NULL,
+    role_id varchar(36) NOT NULL,
+    PRIMARY KEY (user_id, role_id)
+);

--- a/backend/src/main/java/com/platform/marketing/controller/UserRoleMenuController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/UserRoleMenuController.java
@@ -1,0 +1,43 @@
+package com.platform.marketing.controller;
+
+import com.platform.marketing.entity.Menu;
+import com.platform.marketing.service.RoleMenuService;
+import com.platform.marketing.service.UserService;
+import com.platform.marketing.util.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class UserRoleMenuController {
+
+    private final UserService userService;
+    private final RoleMenuService roleMenuService;
+
+    public UserRoleMenuController(UserService userService, RoleMenuService roleMenuService) {
+        this.userService = userService;
+        this.roleMenuService = roleMenuService;
+    }
+
+    @PostMapping("/users/{userId}/roles")
+    @PreAuthorize("hasPermission('user:update')")
+    public ResponseEntity<Void> assignRolesToUser(@PathVariable String userId, @RequestBody List<String> roleIds) {
+        userService.assignRoles(userId, roleIds);
+        return ResponseEntity.success(null);
+    }
+
+    @GetMapping("/users/{userId}/permissions")
+    @PreAuthorize("hasPermission('user:view')")
+    public ResponseEntity<List<Menu>> getUserPermissions(@PathVariable String userId) {
+        return ResponseEntity.success(roleMenuService.getMenusByUser(userId));
+    }
+
+    @PostMapping("/roles/{roleId}/menus")
+    @PreAuthorize("hasPermission('role:update')")
+    public ResponseEntity<Void> assignMenusToRole(@PathVariable String roleId, @RequestBody List<String> menuIds) {
+        roleMenuService.assignMenusToRole(roleId, menuIds);
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/entity/SysRoleMenu.java
+++ b/backend/src/main/java/com/platform/marketing/entity/SysRoleMenu.java
@@ -1,0 +1,27 @@
+package com.platform.marketing.entity;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "role_menu")
+public class SysRoleMenu {
+
+    @EmbeddedId
+    private SysRoleMenuId id;
+
+    public SysRoleMenu() {}
+
+    public SysRoleMenu(SysRoleMenuId id) {
+        this.id = id;
+    }
+
+    public SysRoleMenuId getId() {
+        return id;
+    }
+
+    public void setId(SysRoleMenuId id) {
+        this.id = id;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/entity/SysRoleMenuId.java
+++ b/backend/src/main/java/com/platform/marketing/entity/SysRoleMenuId.java
@@ -1,0 +1,41 @@
+package com.platform.marketing.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class SysRoleMenuId implements Serializable {
+    @Column(name = "role_id", length = 36)
+    private String roleId;
+
+    @Column(name = "menu_id", length = 36)
+    private String menuId;
+
+    public SysRoleMenuId() {}
+
+    public SysRoleMenuId(String roleId, String menuId) {
+        this.roleId = roleId;
+        this.menuId = menuId;
+    }
+
+    public String getRoleId() { return roleId; }
+    public void setRoleId(String roleId) { this.roleId = roleId; }
+
+    public String getMenuId() { return menuId; }
+    public void setMenuId(String menuId) { this.menuId = menuId; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SysRoleMenuId that = (SysRoleMenuId) o;
+        return Objects.equals(roleId, that.roleId) && Objects.equals(menuId, that.menuId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(roleId, menuId);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/entity/SysUserRole.java
+++ b/backend/src/main/java/com/platform/marketing/entity/SysUserRole.java
@@ -1,0 +1,27 @@
+package com.platform.marketing.entity;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "user_role")
+public class SysUserRole {
+
+    @EmbeddedId
+    private UserRoleId id;
+
+    public SysUserRole() {}
+
+    public SysUserRole(UserRoleId id) {
+        this.id = id;
+    }
+
+    public UserRoleId getId() {
+        return id;
+    }
+
+    public void setId(UserRoleId id) {
+        this.id = id;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/repository/RoleMenuRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/RoleMenuRepository.java
@@ -1,0 +1,23 @@
+package com.platform.marketing.repository;
+
+import com.platform.marketing.entity.SysRoleMenu;
+import com.platform.marketing.entity.SysRoleMenuId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+@Repository
+public interface RoleMenuRepository extends JpaRepository<SysRoleMenu, SysRoleMenuId> {
+    List<SysRoleMenu> findByIdRoleId(String roleId);
+    void deleteByIdRoleId(String roleId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM SysRoleMenu rm WHERE rm.id.roleId = :roleId")
+    void deleteByRoleId(@Param("roleId") String roleId);
+}

--- a/backend/src/main/java/com/platform/marketing/service/RoleMenuService.java
+++ b/backend/src/main/java/com/platform/marketing/service/RoleMenuService.java
@@ -1,0 +1,10 @@
+package com.platform.marketing.service;
+
+import com.platform.marketing.entity.Menu;
+
+import java.util.List;
+
+public interface RoleMenuService {
+    void assignMenusToRole(String roleId, List<String> menuIds);
+    List<Menu> getMenusByUser(String userId);
+}

--- a/backend/src/main/java/com/platform/marketing/service/impl/RoleMenuServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/RoleMenuServiceImpl.java
@@ -1,0 +1,58 @@
+package com.platform.marketing.service.impl;
+
+import com.platform.marketing.entity.Menu;
+import com.platform.marketing.entity.SysRoleMenu;
+import com.platform.marketing.entity.SysRoleMenuId;
+import com.platform.marketing.entity.UserRole;
+import com.platform.marketing.repository.MenuRepository;
+import com.platform.marketing.repository.RoleMenuRepository;
+import com.platform.marketing.repository.UserRoleRepository;
+import com.platform.marketing.service.RoleMenuService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+public class RoleMenuServiceImpl implements RoleMenuService {
+
+    private final RoleMenuRepository roleMenuRepository;
+    private final MenuRepository menuRepository;
+    private final UserRoleRepository userRoleRepository;
+
+    public RoleMenuServiceImpl(RoleMenuRepository roleMenuRepository,
+                               MenuRepository menuRepository,
+                               UserRoleRepository userRoleRepository) {
+        this.roleMenuRepository = roleMenuRepository;
+        this.menuRepository = menuRepository;
+        this.userRoleRepository = userRoleRepository;
+    }
+
+    @Override
+    @Transactional
+    public void assignMenusToRole(String roleId, List<String> menuIds) {
+        roleMenuRepository.deleteByRoleId(roleId);
+        if (menuIds != null) {
+            for (String menuId : menuIds) {
+                SysRoleMenuId id = new SysRoleMenuId(roleId, menuId);
+                roleMenuRepository.save(new SysRoleMenu(id));
+            }
+        }
+    }
+
+    @Override
+    public List<Menu> getMenusByUser(String userId) {
+        List<UserRole> roles = userRoleRepository.findByIdUserId(userId);
+        Set<String> menuIds = new HashSet<>();
+        for (UserRole ur : roles) {
+            List<SysRoleMenu> list = roleMenuRepository.findByIdRoleId(ur.getId().getRoleId());
+            for (SysRoleMenu rm : list) {
+                menuIds.add(rm.getId().getMenuId());
+            }
+        }
+        if (menuIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return menuRepository.findAllById(menuIds);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SysRoleMenu` entity and composite key
- add repository/service/controller to assign menus to roles and fetch user permissions
- expose `/api/users/{userId}/roles`, `/api/users/{userId}/permissions` and `/api/roles/{roleId}/menus` endpoints
- extend database schema with `role_menu` and `user_role` tables

## Testing
- `mvn -f backend/pom.xml -q test` *(fails: Non-resolvable parent POM because repo lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6882eda7d72083269d95b3734f1ebdab