### PR TITLE
Implement GET /api/menus/{menuId}/users

### DIFF
--- a/backend/src/main/java/com/platform/marketing/controller/UserRoleMenuController.java
+++ b/backend/src/main/java/com/platform/marketing/controller/UserRoleMenuController.java
@@ -1,6 +1,7 @@
 package com.platform.marketing.controller;
 
 import com.platform.marketing.entity.Menu;
+import com.platform.marketing.entity.User;
 import com.platform.marketing.service.RoleMenuService;
 import com.platform.marketing.service.UserService;
 import com.platform.marketing.util.ResponseEntity;
@@ -39,5 +40,11 @@ public class UserRoleMenuController {
     public ResponseEntity<Void> assignMenusToRole(@PathVariable String roleId, @RequestBody List<String> menuIds) {
         roleMenuService.assignMenusToRole(roleId, menuIds);
         return ResponseEntity.success(null);
+    }
+
+    @GetMapping("/menus/{menuId}/users")
+    @PreAuthorize("hasPermission('menu:view')")
+    public ResponseEntity<List<User>> getUsersByMenu(@PathVariable String menuId) {
+        return ResponseEntity.success(roleMenuService.getUsersByMenu(menuId));
     }
 }

--- a/backend/src/main/java/com/platform/marketing/repository/RoleMenuRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/RoleMenuRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Repository
 public interface RoleMenuRepository extends JpaRepository<SysRoleMenu, SysRoleMenuId> {
     List<SysRoleMenu> findByIdRoleId(String roleId);
+    List<SysRoleMenu> findByIdMenuId(String menuId);
     void deleteByIdRoleId(String roleId);
 
     @Modifying

--- a/backend/src/main/java/com/platform/marketing/repository/UserRoleRepository.java
+++ b/backend/src/main/java/com/platform/marketing/repository/UserRoleRepository.java
@@ -10,5 +10,7 @@ import java.util.List;
 @Repository
 public interface UserRoleRepository extends JpaRepository<UserRole, UserRoleId> {
     List<UserRole> findByIdUserId(String userId);
+    List<UserRole> findByIdRoleId(String roleId);
+    List<UserRole> findByIdRoleIdIn(java.util.Collection<String> roleIds);
     void deleteByIdUserId(String userId);
 }

--- a/backend/src/main/java/com/platform/marketing/service/RoleMenuService.java
+++ b/backend/src/main/java/com/platform/marketing/service/RoleMenuService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface RoleMenuService {
     void assignMenusToRole(String roleId, List<String> menuIds);
     List<Menu> getMenusByUser(String userId);
+    java.util.List<com.platform.marketing.entity.User> getUsersByMenu(String menuId);
 }

--- a/backend/src/main/java/com/platform/marketing/service/impl/RoleMenuServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/service/impl/RoleMenuServiceImpl.java
@@ -4,9 +4,11 @@ import com.platform.marketing.entity.Menu;
 import com.platform.marketing.entity.SysRoleMenu;
 import com.platform.marketing.entity.SysRoleMenuId;
 import com.platform.marketing.entity.UserRole;
+import com.platform.marketing.entity.User;
 import com.platform.marketing.repository.MenuRepository;
 import com.platform.marketing.repository.RoleMenuRepository;
 import com.platform.marketing.repository.UserRoleRepository;
+import com.platform.marketing.repository.UserRepository;
 import com.platform.marketing.service.RoleMenuService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +21,16 @@ public class RoleMenuServiceImpl implements RoleMenuService {
     private final RoleMenuRepository roleMenuRepository;
     private final MenuRepository menuRepository;
     private final UserRoleRepository userRoleRepository;
+    private final UserRepository userRepository;
 
     public RoleMenuServiceImpl(RoleMenuRepository roleMenuRepository,
                                MenuRepository menuRepository,
-                               UserRoleRepository userRoleRepository) {
+                               UserRoleRepository userRoleRepository,
+                               UserRepository userRepository) {
         this.roleMenuRepository = roleMenuRepository;
         this.menuRepository = menuRepository;
         this.userRoleRepository = userRoleRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -54,5 +59,26 @@ public class RoleMenuServiceImpl implements RoleMenuService {
             return Collections.emptyList();
         }
         return menuRepository.findAllById(menuIds);
+    }
+
+    @Override
+    public List<User> getUsersByMenu(String menuId) {
+        List<SysRoleMenu> roleMenus = roleMenuRepository.findByIdMenuId(menuId);
+        if (roleMenus.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> roleIds = new HashSet<>();
+        for (SysRoleMenu rm : roleMenus) {
+            roleIds.add(rm.getId().getRoleId());
+        }
+        List<UserRole> userRoles = userRoleRepository.findByIdRoleIdIn(roleIds);
+        if (userRoles.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> userIds = new HashSet<>();
+        for (UserRole ur : userRoles) {
+            userIds.add(ur.getId().getUserId());
+        }
+        return userRepository.findAllById(userIds);
     }
 }


### PR DESCRIPTION
## Summary
- allow querying users by menu via RoleMenuService
- expose GET `/api/menus/{menuId}/users` endpoint
- support service/repo methods for the user lookup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6882f5325f408326b82645770cc4f005