### PR TITLE
Internationalize sidebar menus

### DIFF
--- a/frontend/src/components/SidebarMenu.vue
+++ b/frontend/src/components/SidebarMenu.vue
@@ -11,20 +11,20 @@ const activeMenu = ref(route.name || 'Dashboard')
 const { t } = useI18n()
 
 const menuItems = [
-  { name: 'Dashboard', label: 'sidebar.dashboard', icon: '📊' },
-  { name: 'CustomerCrawl', label: 'sidebar.customerCrawl', icon: '🔍', permission: 'customer:crawl' },
-  { name: 'CustomerManage', label: 'sidebar.customerManage', icon: '👥', permission: 'customer:manage' },
-  { name: 'ContentGenerate', label: 'sidebar.contentGenerate', icon: '✍️', permission: 'content:generate' },
-  { name: 'EmailMarketing', label: 'sidebar.emailMarketing', icon: '📧', permission: 'email:send' },
-  { name: 'SocialMedia', label: 'sidebar.socialMedia', icon: '📱', permission: 'social:manage' },
-  { name: 'TaskSchedule', label: 'sidebar.taskSchedule', icon: '⏰', permission: 'task:schedule' },
-  { name: 'BehaviorTrack', label: 'sidebar.behaviorTrack', icon: '📈', permission: 'behavior:track' },
-  { name: 'Reports', label: 'sidebar.reports', icon: '📋', permission: 'report:view' },
-  { name: 'Permission', label: 'sidebar.permission', icon: '🔐', permission: 'system:permission' },
-  { name: 'Settings', label: 'sidebar.settings', icon: '⚙️', permission: 'system:setting' },
-  { name: 'CampaignCenter', label: 'sidebar.campaignCenter', icon: '🎯' },
-  { name: 'NotificationCenter', label: 'sidebar.notificationCenter', icon: '🔔' },
-  { name: 'HelpCenter', label: 'sidebar.helpCenter', icon: '❓' }
+  { name: 'Dashboard', label: 'menu.dashboard', icon: '📊' },
+  { name: 'CustomerCrawl', label: 'menu.lead', icon: '🔍', permission: 'customer:crawl' },
+  { name: 'CustomerManage', label: 'menu.customer', icon: '👥', permission: 'customer:manage' },
+  { name: 'ContentGenerate', label: 'menu.content', icon: '✍️', permission: 'content:generate' },
+  { name: 'EmailMarketing', label: 'menu.email', icon: '📧', permission: 'email:send' },
+  { name: 'SocialMedia', label: 'menu.social', icon: '📱', permission: 'social:manage' },
+  { name: 'TaskSchedule', label: 'menu.task', icon: '⏰', permission: 'task:schedule' },
+  { name: 'BehaviorTrack', label: 'menu.behavior', icon: '📈', permission: 'behavior:track' },
+  { name: 'Reports', label: 'menu.reports', icon: '📋', permission: 'report:view' },
+  { name: 'Permission', label: 'menu.permission', icon: '🔐', permission: 'system:permission' },
+  { name: 'Settings', label: 'menu.system', icon: '⚙️', permission: 'system:setting' },
+  { name: 'CampaignCenter', label: 'menu.campaign', icon: '🎯' },
+  { name: 'NotificationCenter', label: 'menu.notification', icon: '🔔' },
+  { name: 'HelpCenter', label: 'menu.help', icon: '❓' }
 ]
 
 const visibleItems = menuItems.filter(i => !i.permission || hasPermission(i.permission))

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -14,7 +14,7 @@
         <el-sub-menu index="system">
           <template #title>
             <el-icon><Setting /></el-icon>
-            <span>系统管理</span>
+            <span>{{ t('menu.system') }}</span>
           </template>
           <el-menu-item
             v-for="item in systemMenus"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3,6 +3,22 @@
     "personalSettings": "Profile",
     "logout": "Logout"
   },
+  "menu": {
+    "dashboard": "Dashboard",
+    "campaign": "Marketing Campaign",
+    "notification": "Notification Center",
+    "lead": "Customer Acquisition",
+    "customer": "Customer Management",
+    "email": "Email Marketing",
+    "social": "Social Marketing",
+    "task": "Task Scheduler",
+    "behavior": "Behavior Tracking",
+    "content": "Content Generate",
+    "system": "System Settings",
+    "reports": "Reports",
+    "permission": "Permission",
+    "help": "Help Center"
+  },
   "sidebar": {
     "dashboard": "Dashboard",
     "customerCrawl": "Customer Crawl",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -3,6 +3,22 @@
     "personalSettings": "个人设置",
     "logout": "退出登录"
   },
+  "menu": {
+    "dashboard": "控制台",
+    "campaign": "营销活动",
+    "notification": "通知中心",
+    "lead": "客户获取",
+    "customer": "客户管理",
+    "email": "邮件营销",
+    "social": "社交营销",
+    "task": "任务调度",
+    "behavior": "行为追踪",
+    "content": "内容生成",
+    "system": "系统设置",
+    "reports": "报表分析",
+    "permission": "权限管理",
+    "help": "帮助中心"
+  },
   "sidebar": {
     "dashboard": "控制台",
     "customerCrawl": "客户抓取",


### PR DESCRIPTION
## Summary
- convert sidebar menu items to i18n keys
- translate system submenu title
- add new `menu` entries in i18n files

## Testing
- `npm run build` *(fails: Rollup failed to resolve 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_688c7e0c17548326baeabb6af5a9f02e