### PR TITLE
feat: add customer import button

### DIFF
--- a/frontend/src/views/customer/CustomerManageView.vue
+++ b/frontend/src/views/customer/CustomerManageView.vue
@@ -10,6 +10,14 @@
           @keyup.enter="fetchData"
         />
         <el-button type="primary" @click="openAdd">新增客户</el-button>
+        <el-upload
+          action="#"
+          :show-file-list="false"
+          accept=".csv,.xlsx"
+          :before-upload="handleCustomerImport"
+        >
+          <el-button type="primary">导入客户</el-button>
+        </el-upload>
       </div>
 
       <el-table
@@ -213,6 +221,11 @@ function changeStatus(row) {
     .then(() => ElMessage.success("状态已更新"))
     .catch(() => ElMessage.error("更新失败"));
 }
+
+const handleCustomerImport = (file) => {
+  console.log("📦 导入客户文件名：", file.name);
+  return false; // 阻止自动上传，保留文件解析能力
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add "导入客户" button to customer management view
- log imported customer file names when uploading

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Rollup failed to resolve import "axios")
- `npm install axios` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68900d4569f483268daba1b95bd0b3c3