### PR TITLE
feat: add customer import button and validate crawl task name

### DIFF
--- a/frontend/src/views/customer/CustomerCrawlView.vue
+++ b/frontend/src/views/customer/CustomerCrawlView.vue
@@ -73,9 +73,9 @@
 
     <!-- 表单抽屉 -->
     <el-drawer v-model="formDrawer" title="新建抓取任务" size="40%">
-      <el-form :model="form" label-width="90px">
-        <el-form-item label="任务名称">
-          <el-input v-model="form.name" />
+      <el-form :model="form" label-width="90px" :rules="rules" ref="formRef">
+        <el-form-item label="任务名称" prop="taskName">
+          <el-input v-model="form.taskName" placeholder="请输入任务名称" />
         </el-form-item>
         <el-form-item label="平台选择">
           <el-select v-model="form.platform" multiple style="width: 100%">
@@ -146,13 +146,18 @@ const previewData = ref([]);
 const formDrawer = ref(false);
 const previewDialog = ref(false);
 
+const formRef = ref();
+const rules = {
+  taskName: [{ required: true, message: '请输入任务名称', trigger: 'blur' }]
+};
+
 const platforms = [
   { label: "LinkedIn", value: "linkedin" },
   { label: "Facebook", value: "facebook" },
 ];
 
 const form = ref({
-  name: "",
+  taskName: "",
   platform: [],
   type: "customer",
   cycle: "once",
@@ -174,7 +179,7 @@ function openCreate() {
   editing.value = false;
   currentId.value = null;
   form.value = {
-    name: "",
+    taskName: "",
     platform: [],
     type: "customer",
     cycle: "once",
@@ -188,7 +193,7 @@ function editRow(row) {
   editing.value = true;
   currentId.value = row.id;
   form.value = {
-    name: row.name,
+    taskName: row.name,
     platform: Array.isArray(row.platform)
       ? row.platform
       : String(row.platform || "")
@@ -212,8 +217,13 @@ async function removeRow(row) {
 }
 
 async function saveTask() {
+  try {
+    await formRef.value.validate();
+  } catch (err) {
+    return;
+  }
   const payload = {
-    name: form.value.name,
+    name: form.value.taskName,
     platform: form.value.platform.join(","), // 改成字符串
     fields: form.value.fields.join(","), // 改成字符串
     type: form.value.type,

--- a/frontend/src/views/customer/CustomerManageView.vue
+++ b/frontend/src/views/customer/CustomerManageView.vue
@@ -10,6 +10,14 @@
           @keyup.enter="fetchData"
         />
         <el-button type="primary" @click="openAdd">新增客户</el-button>
+        <el-upload
+          action="#"
+          :show-file-list="false"
+          accept=".csv,.xlsx"
+          :before-upload="handleCustomerImport"
+        >
+          <el-button type="primary">导入客户</el-button>
+        </el-upload>
       </div>
 
       <el-table
@@ -213,6 +221,11 @@ function changeStatus(row) {
     .then(() => ElMessage.success("状态已更新"))
     .catch(() => ElMessage.error("更新失败"));
 }
+
+const handleCustomerImport = (file) => {
+  console.log("📦 导入客户文件名：", file.name);
+  return false; // 阻止自动上传，保留文件解析能力
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add "导入客户" button to customer management view
- log imported customer file names when uploading
- require task name in crawl task creation with form validation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Rollup failed to resolve import "axios")
- `npm install axios` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68900d4569f483268daba1b95bd0b3c3