### PR TITLE
refactor: replace quill editor with textarea

### DIFF
--- a/frontend/src/views/marketing/EmailMarketingView.vue
+++ b/frontend/src/views/marketing/EmailMarketingView.vue
@@ -1,68 +1,109 @@
 <template>
   <div class="email-marketing">
-    <el-form ref="formRef" :model="form" label-width="100px">
-      <el-form-item
-        :label="t('email.subject')"
-        prop="subject"
-        :rules="[{ required: true, message: t('email.requiredField') }]"
-        ><el-input v-model="form.subject"
-      /></el-form-item>
-      <el-form-item
-        :label="t('email.content')"
-        prop="content"
-        :rules="[{ required: true, message: t('email.requiredField') }]"
-        ><EmailEditor v-model="form.content"
-      /></el-form-item>
-      <el-form-item
-        :label="t('email.recipients')"
-        prop="recipients"
-        :rules="[
-          { type: 'array', required: true, message: t('email.requiredField') },
-        ]"
-        ><RecipientUploader v-model="form.recipients"
-      /></el-form-item>
-      <el-form-item>
-        <el-button type="primary" @click="send">{{
-          t("email.send")
-        }}</el-button>
-        <el-button @click="sendTest">{{ t("email.test") }}</el-button>
-      </el-form-item>
-    </el-form>
-    <h3 style="margin-top: 30px">{{ t("email.history") }}</h3>
-    <EmailHistory />
+    <el-card class="form-card">
+      <el-form ref="formRef" :model="form" label-width="100px">
+        <el-form-item
+          :label="t('email.subject')"
+          prop="subject"
+          :rules="[{ required: true, message: t('email.requiredField') }]"
+        >
+          <el-input v-model="form.subject" />
+        </el-form-item>
+        <el-form-item
+          :label="t('email.content')"
+          prop="content"
+          :rules="[{ required: true, message: t('email.requiredField') }]"
+        >
+          <el-input
+            v-model="form.content"
+            type="textarea"
+            rows="10"
+          />
+        </el-form-item>
+        <el-form-item
+          :label="t('email.recipients')"
+          prop="recipients"
+          :rules="[
+            { type: 'array', required: true, message: t('email.requiredField') },
+          ]"
+        >
+          <el-upload
+            accept=".csv"
+            :show-file-list="false"
+            :http-request="handleCsvUpload"
+          >
+            <el-button>{{ t('email.uploadCSV') }}</el-button>
+          </el-upload>
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="sendEmail">{{
+            t('email.send')
+          }}</el-button>
+          <el-button @click="sendTestEmail">{{ t('email.test') }}</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+    <el-card class="history-card">
+      <h3>{{ t('email.history') }}</h3>
+      <EmailHistory />
+    </el-card>
   </div>
 </template>
 <script setup>
 import { ref } from "vue";
 import { ElMessage } from "element-plus";
 import { useI18n } from "vue-i18n";
-import EmailEditor from "@/components/email/EmailEditor.vue";
-import RecipientUploader from "@/components/email/RecipientUploader.vue";
 import EmailHistory from "@/components/email/EmailHistory.vue";
-import { sendEmail, sendTestEmail } from "@/api/email";
+import $api from "@/utils/request";
 
 const { t } = useI18n();
 const formRef = ref();
 const form = ref({ subject: "", content: "", recipients: [] });
 
-async function send() {
+async function handleCsvUpload({ file, onError, onSuccess }) {
+  const formData = new FormData();
+  formData.append('file', file);
+  try {
+    const res = await $api.post('/email/uploadRecipients', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    form.value.recipients = res?.recipients || [];
+    ElMessage.success(t('email.uploadCSV') + ' success');
+    onSuccess && onSuccess(res);
+  } catch (err) {
+    ElMessage.error(err.message || 'Upload failed');
+    onError && onError(err);
+  }
+}
+
+async function sendEmail() {
   await formRef.value.validate(async (valid) => {
     if (!valid) return;
-    await sendEmail({
-      title: form.value.subject,
-      html: form.value.content,
+    await $api.post('/email/send', {
+      subject: form.value.subject,
+      content: form.value.content,
       recipients: form.value.recipients,
     });
-    ElMessage.success(t("email.send") + " success");
+    ElMessage.success(t('email.send') + ' success');
   });
 }
-async function sendTest() {
-  await sendTestEmail({ title: form.value.subject, html: form.value.content });
-  ElMessage.success(t("email.test") + " success");
+
+async function sendTestEmail() {
+  await $api.post('/email/test', {
+    subject: form.value.subject,
+    content: form.value.content,
+  });
+  ElMessage.success(t('email.test') + ' success');
 }
 </script>
 <style scoped>
 .email-marketing {
   padding: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.history-card {
+  margin-top: 24px;
 }
 </style>


### PR DESCRIPTION
## Summary
- use Element Plus textarea instead of Quill editor for email content
- add CSV recipient upload using Element Plus upload component
- send email and test send via `$api` endpoints

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68902145b3d483269fc15da23fbdf76e