### PR TITLE
feat(email): add basic email sending and CSV upload

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,6 +46,15 @@
             <artifactId>poi-ooxml</artifactId>
             <version>5.2.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/backend/src/main/java/com/platform/marketing/modules/email/controller/EmailController.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/controller/EmailController.java
@@ -1,0 +1,50 @@
+package com.platform.marketing.modules.email.controller;
+
+import com.platform.marketing.modules.email.dto.EmailSendRequest;
+import com.platform.marketing.modules.email.service.EmailService;
+import com.platform.marketing.util.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    public EmailController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @PostMapping("/send")
+    public ResponseEntity<Map<String, Boolean>> sendEmail(@RequestBody EmailSendRequest request) {
+        if (request.getSubject() == null || request.getSubject().trim().isEmpty() ||
+            request.getContent() == null || request.getContent().trim().isEmpty() ||
+            request.getToList() == null || request.getToList().isEmpty()) {
+            return ResponseEntity.fail(400, "subject, content and toList are required");
+        }
+        emailService.sendEmail(request.getSubject(), request.getContent(), request.getToList());
+        Map<String, Boolean> resp = new HashMap<>();
+        resp.put("success", true);
+        return ResponseEntity.success(resp);
+    }
+
+    @PostMapping("/upload-recipients")
+    public ResponseEntity<Map<String, List<String>>> uploadRecipients(@RequestParam("file") MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.fail(400, "file is empty");
+        }
+        List<String> emails = emailService.parseRecipients(file);
+        Map<String, List<String>> resp = new HashMap<>();
+        resp.put("emails", emails);
+        return ResponseEntity.success(resp);
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/dto/EmailSendRequest.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/dto/EmailSendRequest.java
@@ -1,0 +1,33 @@
+package com.platform.marketing.modules.email.dto;
+
+import java.util.List;
+
+public class EmailSendRequest {
+    private String subject;
+    private String content;
+    private List<String> toList;
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public List<String> getToList() {
+        return toList;
+    }
+
+    public void setToList(List<String> toList) {
+        this.toList = toList;
+    }
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/EmailService.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/EmailService.java
@@ -1,0 +1,11 @@
+package com.platform.marketing.modules.email.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface EmailService {
+    void sendEmail(String subject, String content, List<String> toList);
+
+    List<String> parseRecipients(MultipartFile file);
+}

--- a/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailServiceImpl.java
+++ b/backend/src/main/java/com/platform/marketing/modules/email/service/impl/EmailServiceImpl.java
@@ -1,0 +1,61 @@
+package com.platform.marketing.modules.email.service.impl;
+
+import com.platform.marketing.modules.email.service.EmailService;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public EmailServiceImpl(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    @Override
+    public void sendEmail(String subject, String content, List<String> toList) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setSubject(subject);
+            helper.setText(content, true);
+            helper.setTo(toList.toArray(new String[0]));
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("Failed to send email", e);
+        }
+    }
+
+    @Override
+    public List<String> parseRecipients(MultipartFile file) {
+        List<String> emails = new ArrayList<>();
+        try (Reader reader = new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8)) {
+            Iterable<CSVRecord> records = CSVFormat.DEFAULT.parse(reader);
+            for (CSVRecord record : records) {
+                if (record.size() > 0) {
+                    String email = record.get(0).trim();
+                    if (!email.isEmpty()) {
+                        emails.add(email);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse CSV", e);
+        }
+        return emails;
+    }
+}


### PR DESCRIPTION
## Summary
- add controller for sending emails and uploading recipient CSVs
- implement email service using JavaMailSender and Apache Commons CSV
- add mail and CSV dependencies to Maven build

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68902703993c83268fea7581d21f1039