### PR TITLE
feat: add keyword search stat to dashboard

### DIFF
--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -25,3 +25,12 @@ export function getRecentTasks() {
 export function getTaskDetail(id) {
   return request.get(`/api/dashboard/tasks/${id}`);
 }
+
+// 获取关键词搜索量
+export function getKeywordSearchCount(keyword) {
+  return request({
+    url: '/v1/dashboard/keyword-search-count',
+    method: 'get',
+    params: { keyword }
+  });
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -140,5 +140,10 @@
     "history": "Send Records",
     "insertImage": "Insert Image",
     "requiredField": "Required field cannot be empty"
+  },
+  "dashboard": {
+    "keyword": "Keyword",
+    "search": "Search",
+    "keywordSearchCount": "Keyword Search Volume"
   }
 }

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -140,5 +140,10 @@
     "history": "发送记录",
     "insertImage": "插入图片",
     "requiredField": "必填项不能为空"
+  },
+  "dashboard": {
+    "keyword": "关键词",
+    "search": "搜索",
+    "keywordSearchCount": "关键词搜索量"
   }
 }

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, onMounted } from "vue";
+import { useI18n } from "vue-i18n";
 import StatCard from "@/components/StatCard.vue";
 import LineChart from "@/components/charts/LineChart.vue";
 
@@ -9,6 +10,7 @@ import {
   getCustomerTrend,
   getRecentTasks,
   getTaskDetail,
+  getKeywordSearchCount,
 } from "@/api/dashboard";
 
 const stats = ref({});
@@ -18,6 +20,10 @@ const currentTask = ref({});
 const chartTab = ref("send");
 const sendTrend = ref([]);
 const customerTrend = ref([]);
+
+const keyword = ref("");
+const keywordStat = ref(null);
+const { t } = useI18n();
 
 onMounted(() => {
   getDashboardStats().then((res) => (stats.value = res));
@@ -32,6 +38,13 @@ function viewTask(row) {
     drawerVisible.value = true;
   });
 }
+
+function searchKeyword() {
+  if (!keyword.value) return;
+  getKeywordSearchCount(keyword.value).then((res) => {
+    keywordStat.value = res.data;
+  });
+}
 </script>
 
 <template>
@@ -41,6 +54,22 @@ function viewTask(row) {
       <StatCard title="今日邮件发送" :value="stats.emailsSent" />
       <StatCard title="邮件打开率" :value="stats.openRate + '%'" />
       <StatCard title="运行中任务" :value="stats.runningTasks" />
+      <StatCard
+        v-if="keywordStat"
+        :title="`${t('dashboard.keywordSearchCount')} - ${keywordStat.keyword}`"
+        :value="keywordStat.count"
+      />
+    </div>
+
+    <div class="keyword-search">
+      <el-input
+        v-model="keyword"
+        :placeholder="t('dashboard.keyword')"
+        class="keyword-input"
+      />
+      <el-button type="primary" @click="searchKeyword">
+        {{ t('dashboard.search') }}
+      </el-button>
     </div>
 
     <el-card class="chart-container">
@@ -104,3 +133,15 @@ function viewTask(row) {
     </el-drawer>
   </div>
 </template>
+
+<style scoped>
+.keyword-search {
+  margin: 20px 0;
+  display: flex;
+  gap: 10px;
+  max-width: 400px;
+}
+.keyword-input {
+  flex: 1;
+}
+</style>


### PR DESCRIPTION
## Summary
- add keyword search form and display stat card on dashboard
- support keyword search count API
- provide i18n strings for keyword search

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68904e231738832692fde7068bc924d0