### PR TITLE
feat: register MethodSecurity permission configuration

### DIFF
--- a/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
+++ b/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
@@ -1,0 +1,26 @@
+package com.platform.marketing.config;
+
+import com.platform.marketing.auth.CustomMethodSecurityExpressionHandler;
+import com.platform.marketing.auth.CustomPermissionEvaluator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    @Bean
+    public CustomPermissionEvaluator customPermissionEvaluator() {
+        return new CustomPermissionEvaluator();
+    }
+
+    @Override
+    protected CustomMethodSecurityExpressionHandler createExpressionHandler() {
+        CustomMethodSecurityExpressionHandler expressionHandler =
+            new CustomMethodSecurityExpressionHandler(customPermissionEvaluator());
+        expressionHandler.setPermissionEvaluator(customPermissionEvaluator());
+        return expressionHandler;
+    }
+}


### PR DESCRIPTION
## Summary
- add MethodSecurityConfig to wire custom permission evaluator and expression handler for method-level security

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890584324fc8326ab070b43ab0ac817