### PR TITLE
fix: make JwtAuthenticationFilter a Spring bean

### DIFF
--- a/backend/src/main/java/com/platform/marketing/auth/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/platform/marketing/auth/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.platform.marketing.auth;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -19,6 +20,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
 
+    @Autowired
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
     }

--- a/backend/src/main/java/com/platform/marketing/config/SecurityConfig.java
+++ b/backend/src/main/java/com/platform/marketing/config/SecurityConfig.java
@@ -2,9 +2,10 @@ package com.platform.marketing.config;
 
 import com.platform.marketing.auth.JwtAuthenticationFilter;
 import com.platform.marketing.auth.UserDetailsServiceImpl;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,6 +23,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final UserDetailsServiceImpl userDetailsService;
 
+    @Autowired
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, @Lazy UserDetailsServiceImpl userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.userDetailsService = userDetailsService;

--- a/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
+++ b/src/main/java/com/platform/marketing/config/MethodSecurityConfig.java
@@ -1,0 +1,26 @@
+package com.platform.marketing.config;
+
+import com.platform.marketing.auth.CustomMethodSecurityExpressionHandler;
+import com.platform.marketing.auth.CustomPermissionEvaluator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    @Bean
+    public CustomPermissionEvaluator customPermissionEvaluator() {
+        return new CustomPermissionEvaluator();
+    }
+
+    @Override
+    protected CustomMethodSecurityExpressionHandler createExpressionHandler() {
+        CustomMethodSecurityExpressionHandler expressionHandler =
+            new CustomMethodSecurityExpressionHandler(customPermissionEvaluator());
+        expressionHandler.setPermissionEvaluator(customPermissionEvaluator());
+        return expressionHandler;
+    }
+}


### PR DESCRIPTION
## Summary
- add `MethodSecurityConfig` to wire custom permission evaluator
- register `JwtAuthenticationFilter` as a Spring bean and inject it into `SecurityConfig`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890584324fc8326ab070b43ab0ac817