### PR TITLE
style: apply customer acquisition theme to console layout

### DIFF
--- a/frontend/src/components/HeaderBar.vue
+++ b/frontend/src/components/HeaderBar.vue
@@ -31,7 +31,7 @@ function changeLang(lang) {
 
 <template>
   <div class="header">
-    <h2 style="margin: 0; color: #333">{{ t(titleMap[route.path] || "") }}</h2>
+    <h2>{{ t(titleMap[route.path] || "") }}</h2>
     <div class="user-info">
       <el-badge :value="3" type="primary">
         <el-button type="text" size="large"
@@ -50,9 +50,7 @@ function changeLang(lang) {
         </template>
       </el-dropdown>
       <el-dropdown>
-        <div
-          style="display: flex; align-items: center; gap: 8px; cursor: pointer"
-        >
+        <div class="user-trigger">
           <el-avatar :src="store.currentUser?.avatar" />
           <span>{{ store.currentUser?.name }}</span>
         </div>
@@ -74,3 +72,40 @@ function changeLang(lang) {
     </div>
   </div>
 </template>
+
+<style scoped>
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: var(--om-font-lg);
+  font-weight: var(--om-font-bold);
+  color: var(--om-text-primary);
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: var(--om-space-4);
+  color: var(--om-text-primary);
+}
+
+.lang-select {
+  cursor: pointer;
+}
+
+.icon {
+  font-size: var(--om-font-lg);
+}
+
+.user-trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--om-space-2);
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,36 +1,6 @@
 <template>
   <div class="system-container">
-    <div class="sidebar">
-      <div class="logo">🌍 {{ t("sidebar.brand") }}</div>
-      <el-menu :default-active="activeMenu" @select="handleSelect">
-        <!-- 左侧非系统菜单 -->
-        <el-menu-item
-          v-for="item in otherMenus"
-          :key="item.path"
-          :index="item.path"
-        >
-          <el-icon><component :is="item.icon" /></el-icon>
-          <span>{{ t(item.i18nKey) }}</span>
-        </el-menu-item>
-
-        <!-- 系统菜单 -->
-        <el-sub-menu index="system">
-          <template #title>
-            <el-icon><Setting /></el-icon>
-            <span>{{ t("menu.system") }}</span>
-          </template>
-          <el-menu-item
-            v-for="item in systemMenus"
-            :key="item.path"
-            :index="item.path"
-          >
-            <el-icon><component :is="item.icon" /></el-icon>
-            <span>{{ t(item.i18nKey) }}</span>
-          </el-menu-item>
-        </el-sub-menu>
-      </el-menu>
-    </div>
-
+    <SidebarMenu />
     <div class="main-content">
       <HeaderBar class="header" />
       <div class="content-area">
@@ -41,99 +11,15 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from "vue";
-import { useRouter, useRoute } from "vue-router";
-import { useI18n } from "vue-i18n";
-import HeaderBar from "../components/HeaderBar.vue";
-import { fetchMenuTree } from "@/api/menu";
-import * as Icons from "@element-plus/icons-vue";
-
-// 路由控制
-const router = useRouter();
-const route = useRoute();
-const { t } = useI18n();
-const activeMenu = ref(route.path);
-watch(
-  () => route.path,
-  (val) => (activeMenu.value = val)
-);
-
-// 菜单数据
-const otherMenus = ref([]);
-const systemMenus = ref([]);
-
-// 中文 → 国际化 key 映射表
-const nameMap = {
-  控制台: "menu.dashboard",
-  营销活动: "menu.campaign",
-  通知中心: "menu.notification",
-  客户采集: "menu.lead",
-  客户管理: "menu.customer",
-  邮件营销: "menu.email",
-  社交营销: "menu.social",
-  任务调度: "menu.task",
-  行为追踪: "menu.behavior",
-  内容生成: "menu.content",
-  系统设置: "menu.system",
-  权限管理: "menu.permission",
-  菜单管理: "sidebar.menuManage",
-};
-
-// 生命周期挂载时获取菜单
-onMounted(async () => {
-  const res = await fetchMenuTree();
-  const all = flatten(res.data || []);
-
-  systemMenus.value = all.filter(
-    (i) =>
-      i.path?.startsWith("/permission") ||
-      i.path?.startsWith("/settings") ||
-      i.path?.startsWith("/system/")
-  );
-  otherMenus.value = all.filter((i) => !systemMenus.value.includes(i));
-});
-
-// 扁平化 + 增加 i18nKey 支持
-function flatten(tree) {
-  const result = [];
-  const walk = (nodes) => {
-    nodes.forEach((node) => {
-      const i18nKey = nameMap[node.name] || node.name;
-      result.push({
-        path: node.path,
-        i18nKey,
-        icon: Icons[node.icon] || Icons.Menu,
-      });
-      if (node.children?.length) walk(node.children);
-    });
-  };
-  walk(tree);
-  return result;
-}
-
-// 菜单点击跳转
-function handleSelect(index) {
-  router.push(index);
-}
+import HeaderBar from "@/components/HeaderBar.vue";
+import SidebarMenu from "@/components/SidebarMenu.vue";
 </script>
 
 <style scoped>
 .system-container {
   display: flex;
-  height: 100vh;
-}
-
-.sidebar {
-  width: 220px;
-  background-color: #fff;
-  border-right: 1px solid #eee;
-}
-
-.logo {
-  padding: 20px;
-  font-weight: bold;
-  text-align: center;
-  font-size: 16px;
+  min-height: 100vh;
+  background: var(--om-bg-gradient-primary);
 }
 
 .main-content {
@@ -142,9 +28,16 @@ function handleSelect(index) {
   flex-direction: column;
 }
 
+.header {
+  background: var(--om-glass-bg-strong);
+  border-bottom: 1px solid var(--om-glass-border-strong);
+  backdrop-filter: var(--om-glass-backdrop-strong);
+  padding: var(--om-space-4) var(--om-space-6);
+}
+
 .content-area {
   flex: 1;
   overflow: auto;
-  padding: 20px;
+  padding: var(--om-space-6);
 }
 </style>


### PR DESCRIPTION
## Summary
- replace basic sidebar with `SidebarMenu` and apply customer acquisition design tokens
- style header bar and layout using neon/dark palette

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ad836cfb48326b2c842809015d38f